### PR TITLE
Release v1.0.0 (retry)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,7 +23,7 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.RELEASE_PAT }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4
@@ -111,11 +111,11 @@ jobs:
             - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.RELEASE_PAT }}
 
             - name: Sync master to develop
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -136,7 +136,7 @@ jobs:
 
             - name: Delete release branch
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.RELEASE_PAT }}
                   HEAD_REF: ${{ github.event.pull_request.head.ref }}
               run: |
                   echo "Deleting branch: $HEAD_REF"


### PR DESCRIPTION
## Summary

Retry of #66 which merged but failed to deploy due to missing `RELEASE_PAT` permissions.

### Fixes since #66
- Use `RELEASE_PAT` environment secret for git push operations
- Add release branch ruleset (only maintainers can create)
- Add deployment branch policies to secure environment secrets

## Test plan
- [ ] Verify deploy workflow succeeds
- [ ] Confirm version bump pushed to master
- [ ] Confirm sync to develop completes