### PR TITLE
Release v1.0.0 (retry #2)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,21 +1,69 @@
 name: Deploy Production
 
 on:
-    pull_request:
+    push:
         branches: [master]
-        types: [closed]
 
 jobs:
-    check-label:
-        if: github.event.pull_request.merged == true
-        uses: ./.github/workflows/check-release-label.yml
-        with:
-            labels: ${{ toJson(github.event.pull_request.labels.*.name) }}
-            require: true
-            head_ref: ${{ github.event.pull_request.head.ref }}
+    get-pr-info:
+        runs-on: ubuntu-latest
+        outputs:
+            should_deploy: ${{ steps.lookup.outputs.should_deploy }}
+            bump_type: ${{ steps.lookup.outputs.bump_type }}
+            head_ref: ${{ steps.lookup.outputs.head_ref }}
+            pr_number: ${{ steps.lookup.outputs.pr_number }}
+
+        steps:
+            - name: Lookup merged PR
+              id: lookup
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  # Check if this is an automated commit (e.g., version bump)
+                  AUTHOR=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}" --jq '.author.login')
+                  if [ "$AUTHOR" = "github-actions[bot]" ]; then
+                      echo "Automated commit by $AUTHOR, skipping deploy"
+                      echo "should_deploy=false" >> $GITHUB_OUTPUT
+                      exit 0
+                  fi
+
+                  # Find PR associated with this commit
+                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0]' 2>/dev/null || echo "")
+
+                  if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "null" ]; then
+                      echo "::error::No PR found for commit ${{ github.sha }}"
+                      exit 1
+                  fi
+
+                  PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number')
+                  HEAD_REF=$(echo "$PR_DATA" | jq -r '.head.ref')
+                  echo "Found PR #$PR_NUMBER from branch $HEAD_REF"
+
+                  # Get labels from PR
+                  LABELS=$(echo "$PR_DATA" | jq -r '.labels[].name')
+                  echo "Labels: $LABELS"
+
+                  # Determine bump type from labels
+                  if echo "$LABELS" | grep -q 'release:major'; then
+                      BUMP_TYPE="major"
+                  elif echo "$LABELS" | grep -q 'release:minor'; then
+                      BUMP_TYPE="minor"
+                  elif echo "$LABELS" | grep -q 'release:patch'; then
+                      BUMP_TYPE="patch"
+                  else
+                      echo "::error::No release label found on PR #$PR_NUMBER"
+                      exit 1
+                  fi
+
+                  echo "Bump type: $BUMP_TYPE"
+                  echo "should_deploy=true" >> $GITHUB_OUTPUT
+                  echo "bump_type=$BUMP_TYPE" >> $GITHUB_OUTPUT
+                  echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+                  echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
     deploy:
-        needs: check-label
+        needs: get-pr-info
+        if: needs.get-pr-info.outputs.should_deploy == 'true'
         runs-on: ubuntu-latest
         environment: production
 
@@ -40,8 +88,8 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
 
-                  BUMP_TYPE="${{ needs.check-label.outputs.type }}"
-                  HEAD_REF="${{ github.event.pull_request.head.ref }}"
+                  BUMP_TYPE="${{ needs.get-pr-info.outputs.bump_type }}"
+                  HEAD_REF="${{ needs.get-pr-info.outputs.head_ref }}"
                   CURRENT_VERSION=$(node -p "require('./package.json').version")
 
                   echo "Source branch: $HEAD_REF"
@@ -103,9 +151,10 @@ jobs:
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 
     sync-develop:
-        needs: deploy
-        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        needs: [get-pr-info, deploy]
+        if: startsWith(needs.get-pr-info.outputs.head_ref, 'release/')
         runs-on: ubuntu-latest
+        environment: production
 
         steps:
             - uses: actions/checkout@v4
@@ -137,7 +186,7 @@ jobs:
             - name: Delete release branch
               env:
                   GH_TOKEN: ${{ secrets.RELEASE_PAT }}
-                  HEAD_REF: ${{ github.event.pull_request.head.ref }}
               run: |
+                  HEAD_REF="${{ needs.get-pr-info.outputs.head_ref }}"
                   echo "Deleting branch: $HEAD_REF"
                   git push origin --delete "$HEAD_REF"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,6 +226,37 @@ Commits to release branches auto-deploy to the production CDN for testing (witho
 2. **Release prep** → create `release/X.Y.Z[-suffix]` from `develop`
 3. **Testing** → commits to release branch deploy to production CDN (no aliases)
 4. **Release** → PR to `master` with release label → version bump + alias updates
+5. **Post-release** → master auto-syncs to develop, release branch deleted
+
+### Repository Setup
+
+The release workflow requires specific GitHub configuration. Run `./scripts/setup-github.sh` to configure:
+
+**Rulesets:**
+```bash
+./scripts/setup-github.sh rulesets apply
+```
+- `master-protection` - require PR, approvals, status checks
+- `develop-protection` - require PR, status checks (no approval needed)
+- `release-protection` - only maintainers can create/delete `release/*` branches
+
+**Environments:**
+```bash
+./scripts/setup-github.sh environments apply
+```
+- `production` - restricted to `master` and `release/*` branches
+- `staging` - restricted to `develop` branch
+
+**Secrets:**
+
+The production environment requires a `RELEASE_PAT` secret for pushing version commits:
+
+1. Create a fine-grained PAT at https://github.com/settings/tokens?type=beta
+   - Repository access: this repo only
+   - Permissions: Contents (read/write), Pull requests (read/write)
+2. Add as environment secret in `production` (not repository secret)
+
+See the [deployment guide](https://github.com/streamlinedcms/planning/blob/master/guides/cloudflare-github-deployment.md#cicd-security) for security details.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add this script tag to your HTML `<head>`:
 
 ```html
 <script
-    src="https://cdn.streamlinedcms.com/client-sdk/v0.1/streamlined-cms.min.js"
+    src="https://cdn.streamlinedcms.com/client-sdk/v1/streamlined-cms.min.js"
     data-app-id="YOUR_APP_ID"
 ></script>
 ```
@@ -32,7 +32,7 @@ Get your App ID from [app.streamlinedcms.com](https://app.streamlinedcms.com).
 <html>
 <head>
     <script
-        src="https://cdn.streamlinedcms.com/client-sdk/v0.1/streamlined-cms.min.js"
+        src="https://cdn.streamlinedcms.com/client-sdk/v1/streamlined-cms.min.js"
         data-app-id="YOUR_APP_ID"
     ></script>
 </head>

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -13,7 +13,7 @@ Add this script tag to your HTML `<head>` (not at the end of `<body>`):
 ```html
 <head>
     <script
-        src="https://cdn.streamlinedcms.com/client-sdk/v0.1/streamlined-cms.min.js"
+        src="https://cdn.streamlinedcms.com/client-sdk/v1/streamlined-cms.min.js"
         data-app-id="YOUR_APP_ID"
     ></script>
 </head>
@@ -228,7 +228,7 @@ The SDK automatically:
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>My Website</title>
     <script
-        src="https://cdn.streamlinedcms.com/client-sdk/v0.1/streamlined-cms.min.js"
+        src="https://cdn.streamlinedcms.com/client-sdk/v1/streamlined-cms.min.js"
         data-app-id="YOUR_APP_ID"
     ></script>
 </head>


### PR DESCRIPTION
Retry of #67 after fixing the deploy workflow trigger.

## Changes since #67
- Changed deploy-prod.yml from `pull_request` to `push` trigger
- Added `get-pr-info` job to look up merged PR via API for labels
- Documented repository setup requirements in CONTRIBUTING.md
- Updated CDN URLs for v1 release

## Why the retry
PR #67 deploy failed because `pull_request` events run on `refs/pull/N/merge` which doesn't match the production environment's allowed branches (`master`, `release/*`). The new `push` trigger runs on `refs/heads/master` which matches.