### PR TITLE
Release v1.0.0 (retry #3)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,11 +27,24 @@ jobs:
                       exit 0
                   fi
 
-                  # Find PR associated with this commit
-                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0]' 2>/dev/null || echo "")
+                  # Get parent commits
+                  PARENTS=($(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}" --jq '.parents[].sha'))
+                  echo "Parent commits: ${PARENTS[*]}"
+
+                  if [ ${#PARENTS[@]} -ne 2 ]; then
+                      echo "Not a merge commit (${#PARENTS[@]} parent(s)), skipping deploy"
+                      echo "should_deploy=false" >> $GITHUB_OUTPUT
+                      exit 0
+                  fi
+
+                  # Parent 2 is the PR branch HEAD
+                  PR_BRANCH_SHA="${PARENTS[1]}"
+                  echo "Looking up PR for branch HEAD: $PR_BRANCH_SHA"
+
+                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/$PR_BRANCH_SHA/pulls" --jq '.[0]' 2>/dev/null || echo "")
 
                   if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "null" ]; then
-                      echo "::error::No PR found for commit ${{ github.sha }}"
+                      echo "::error::No PR found for commit $PR_BRANCH_SHA"
                       exit 1
                   fi
 


### PR DESCRIPTION
Retry of #68 after fixing PR lookup in deploy workflow.

## Fix
Changed PR lookup to use merge commit's second parent (the PR branch HEAD) instead of the merge commit itself. The `/commits/{sha}/pulls` API doesn't return results for merge commits.

## Previous failures
- #67: Environment branch policy mismatch (`refs/pull/N/merge` vs `refs/heads/master`)
- #68: PR lookup failed on merge commit