### PR TITLE
Bug fixes, undo system, and content viewer overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6872,24 +6872,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yaml": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",

--- a/src/components/content-viewer-badge.ts
+++ b/src/components/content-viewer-badge.ts
@@ -1,0 +1,72 @@
+/**
+ * Content Viewer Badge Component
+ *
+ * A floating pill that appears over an editable element when the content viewer
+ * is active. Shows the element type icon and element ID. Clicking it selects
+ * that element for editing.
+ */
+
+import { html, css } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { ScmsElement } from "./base.js";
+import { renderTypeIcon } from "./type-icon.js";
+
+@customElement("scms-content-viewer-badge")
+export class ContentViewerBadge extends ScmsElement {
+    @property({ type: String, attribute: "element-key" })
+    elementKey = "";
+
+    @property({ type: String, attribute: "element-id" })
+    elementId = "";
+
+    @property({ type: String, attribute: "element-type" })
+    elementType = "";
+
+    static styles = [
+        ...ScmsElement.styles,
+        css`
+            :host {
+                position: fixed;
+                z-index: 10002;
+                pointer-events: auto;
+                font-family:
+                    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+                    sans-serif;
+            }
+        `,
+    ];
+
+    private handleClick(e: Event) {
+        e.stopPropagation();
+        this.dispatchEvent(
+            new CustomEvent("badge-click", {
+                detail: { key: this.elementKey },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    render() {
+        return html`
+            <button
+                class="inline-flex items-center gap-1 px-2 py-0.5 text-[11px] font-mono text-gray-700 bg-white border border-gray-300 rounded-full shadow-md hover:bg-red-50 hover:border-red-300 hover:text-red-700 transition-colors cursor-pointer whitespace-nowrap"
+                @click=${this.handleClick}
+                title=${this.elementKey}
+            >
+                ${renderTypeIcon(
+                    this.elementType,
+                    "w-3 h-3 text-gray-500 shrink-0",
+                    "w-3 h-3 text-gray-500 shrink-0 -translate-y-px",
+                )}
+                <span class="max-w-[120px] truncate">${this.elementId}</span>
+            </button>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "scms-content-viewer-badge": ContentViewerBadge;
+    }
+}

--- a/src/components/content-viewer-panel.ts
+++ b/src/components/content-viewer-panel.ts
@@ -1,0 +1,133 @@
+/**
+ * Content Viewer Panel Component
+ *
+ * A panel listing editable elements that are hidden, off-screen, or have
+ * zero dimensions. Positioned above the toolbar in the bottom-right corner.
+ * Clicking an item dispatches an event to scroll to and select that element.
+ */
+
+import { html, css, nothing } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { X } from "lucide-static";
+import { ScmsElement } from "./base.js";
+import { renderTypeIcon } from "./type-icon.js";
+
+export interface HiddenElementInfo {
+    key: string;
+    elementId: string;
+    elementType: string;
+    reason: string;
+}
+
+@customElement("scms-content-viewer-panel")
+export class ContentViewerPanel extends ScmsElement {
+    @property({ type: Array })
+    hiddenElements: HiddenElementInfo[] = [];
+
+    static styles = [
+        ...ScmsElement.styles,
+        css`
+            :host {
+                position: fixed;
+                bottom: 60px;
+                right: 16px;
+                z-index: 10001;
+                font-family:
+                    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial,
+                    sans-serif;
+            }
+
+            button {
+                cursor: pointer;
+            }
+        `,
+    ];
+
+    private handleClose() {
+        this.dispatchEvent(
+            new CustomEvent("close", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private handleElementClick(key: string) {
+        this.dispatchEvent(
+            new CustomEvent("hidden-element-click", {
+                detail: { key },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private renderReasonBadge(reason: string) {
+        const colorClass =
+            reason === "off-screen"
+                ? "bg-blue-100 text-blue-600"
+                : reason === "zero size"
+                  ? "bg-orange-100 text-orange-600"
+                  : "bg-gray-100 text-gray-600";
+
+        return html`<span class="text-[10px] px-1.5 py-0.5 rounded-full ${colorClass}"
+            >${reason}</span
+        >`;
+    }
+
+    render() {
+        if (this.hiddenElements.length === 0) {
+            return nothing;
+        }
+
+        return html`
+            <div
+                class="bg-white rounded-lg shadow-xl min-w-[240px] max-w-[320px] max-h-[calc(100vh-76px)] flex flex-col"
+            >
+                <div class="flex items-center justify-between p-4 pb-3 shrink-0">
+                    <div class="font-semibold text-sm text-gray-700">
+                        Hidden Elements (${this.hiddenElements.length})
+                    </div>
+                    <button
+                        class="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600 [&>svg]:w-[18px] [&>svg]:h-[18px]"
+                        @click=${this.handleClose}
+                        aria-label="Close"
+                    >
+                        ${unsafeSVG(X)}
+                    </button>
+                </div>
+
+                <div class="overflow-y-auto px-4 pb-4">
+                    ${this.hiddenElements.map(
+                        (el) => html`
+                            <button
+                                class="block w-full text-left p-2.5 mb-1.5 last:mb-0 border border-gray-200 rounded-md bg-gray-50 hover:bg-gray-100 hover:border-gray-300 transition-all"
+                                @click=${() => this.handleElementClick(el.key)}
+                                title=${el.key}
+                            >
+                                <div
+                                    class="flex items-center gap-1.5 text-xs font-mono text-gray-700"
+                                >
+                                    ${renderTypeIcon(
+                                        el.elementType,
+                                        "w-3 h-3 text-gray-500 shrink-0",
+                                        "w-3 h-3 text-gray-500 shrink-0 -translate-y-px",
+                                    )}
+                                    <span class="truncate">${el.elementId}</span>
+                                    ${this.renderReasonBadge(el.reason)}
+                                </div>
+                            </button>
+                        `,
+                    )}
+                </div>
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "scms-content-viewer-panel": ContentViewerPanel;
+    }
+}

--- a/src/components/element-badge.ts
+++ b/src/components/element-badge.ts
@@ -8,6 +8,7 @@
 import { html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { ScmsElement } from "./base.js";
+import { renderTypeIcon } from "./type-icon.js";
 
 @customElement("scms-element-badge")
 export class ElementBadge extends ScmsElement {
@@ -18,79 +19,6 @@ export class ElementBadge extends ScmsElement {
     elementType: string | null = null;
 
     static styles = [...ScmsElement.styles];
-
-    private renderTypeIcon() {
-        const iconClass = "w-3.5 h-3.5 text-gray-500 shrink-0";
-        const iconClassAdjusted = "w-3.5 h-3.5 text-gray-500 shrink-0 -translate-y-px";
-
-        switch (this.elementType) {
-            case "text":
-                // "T" text icon
-                return html`
-                    <svg
-                        class=${iconClassAdjusted}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                    >
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M4 4h16M12 4v16"
-                        />
-                    </svg>
-                `;
-            case "html":
-                // Code/HTML icon
-                return html`
-                    <svg
-                        class=${iconClassAdjusted}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                    >
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                        />
-                    </svg>
-                `;
-            case "image":
-                // Image icon
-                return html`
-                    <svg class=${iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                        />
-                    </svg>
-                `;
-            case "link":
-                // Link icon
-                return html`
-                    <svg
-                        class=${iconClassAdjusted}
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        stroke="currentColor"
-                    >
-                        <path
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                        />
-                    </svg>
-                `;
-            default:
-                return null;
-        }
-    }
 
     render() {
         if (!this.elementId) {
@@ -108,7 +36,7 @@ export class ElementBadge extends ScmsElement {
                 <span
                     class="text-xs text-gray-600 font-mono bg-gray-100 px-2 py-1 rounded inline-flex items-center gap-1.5"
                 >
-                    ${this.renderTypeIcon()}${this.elementId}
+                    ${renderTypeIcon(this.elementType)}${this.elementId}
                 </span>
             </div>
         `;

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -12,7 +12,16 @@
 import { html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { unsafeSVG } from "lit/directives/unsafe-svg.js";
-import { CircleHelp, ChevronUp, ChevronDown, Ellipsis, Layers, Plus, ScanEye, Trash2 } from "lucide-static";
+import {
+    CircleHelp,
+    ChevronUp,
+    ChevronDown,
+    Ellipsis,
+    Layers,
+    Plus,
+    ScanEye,
+    Trash2,
+} from "lucide-static";
 import { ScmsElement } from "./base.js";
 import type { EditorMode } from "./mode-toggle.js";
 import "./mode-toggle.js";
@@ -664,7 +673,10 @@ export class Toolbar extends ScmsElement {
                     ? html`<button
                           class="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-orange-500 text-white text-[10px] font-bold rounded-full leading-none"
                           @click=${this.handleShowHiddenElements}
-                          title="${this.hiddenElementCount} hidden element${this.hiddenElementCount === 1 ? "" : "s"}"
+                          title="${this.hiddenElementCount} hidden element${this
+                              .hiddenElementCount === 1
+                              ? ""
+                              : "s"}"
                           aria-label="Show hidden elements"
                       >
                           ${this.hiddenElementCount}
@@ -698,8 +710,18 @@ export class Toolbar extends ScmsElement {
                 title="Undo"
                 aria-label="Undo"
             >
-                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a5 5 0 0 1 0 10H9" />
+                <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M3 10h10a5 5 0 0 1 0 10H9"
+                    />
                     <path stroke-linecap="round" stroke-linejoin="round" d="M7 6L3 10l4 4" />
                 </svg>
             </button>
@@ -749,8 +771,7 @@ export class Toolbar extends ScmsElement {
 
                     <!-- Right: Undo + Content Viewer + Save + Sign Out + Admin + Help -->
                     <div class="flex items-center">
-                        ${this.renderUndoButton()}
-                        ${this.renderContentViewerButton()}
+                        ${this.renderUndoButton()} ${this.renderContentViewerButton()}
                         ${this.hasChanges
                             ? html`<span class="mx-3">${this.renderSaveButton()}</span>`
                             : nothing}
@@ -764,9 +785,7 @@ export class Toolbar extends ScmsElement {
                                       ? nothing
                                       : html`<span class="ml-2">${this.renderAdminLink()}</span>`}
                               </div>`}
-                        <div class="ml-3 flex items-center gap-1">
-                            ${this.renderHelpButton()}
-                        </div>
+                        <div class="ml-3 flex items-center gap-1">${this.renderHelpButton()}</div>
                     </div>
                 </div>
             </div>
@@ -1141,7 +1160,10 @@ export class Toolbar extends ScmsElement {
                     </div>
 
                     <!-- Center: Undo -->
-                    <div class="flex items-center justify-center" @click=${(e: Event) => e.stopPropagation()}>
+                    <div
+                        class="flex items-center justify-center"
+                        @click=${(e: Event) => e.stopPropagation()}
+                    >
                         ${this.renderUndoButton()}
                     </div>
 

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -80,6 +80,12 @@ export class Toolbar extends ScmsElement {
     @property({ type: Number, attribute: "hidden-element-count" })
     hiddenElementCount = 0;
 
+    @property({ type: Boolean, attribute: "can-undo" })
+    canUndo = false;
+
+    @property({ type: Boolean, attribute: "can-redo" })
+    canRedo = false;
+
     @property({ type: Boolean, reflect: true })
     expanded = false;
 
@@ -262,6 +268,24 @@ export class Toolbar extends ScmsElement {
     private handleReset() {
         this.dispatchEvent(
             new CustomEvent("reset", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private handleUndo() {
+        this.dispatchEvent(
+            new CustomEvent("undo", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private handleRedo() {
+        this.dispatchEvent(
+            new CustomEvent("redo", {
                 bubbles: true,
                 composed: true,
             }),
@@ -664,6 +688,24 @@ export class Toolbar extends ScmsElement {
         `;
     }
 
+    private renderUndoButton() {
+        if (!this.canUndo) return nothing;
+
+        return html`
+            <button
+                class="w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors"
+                @click=${this.handleUndo}
+                title="Undo"
+                aria-label="Undo"
+            >
+                <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h10a5 5 0 0 1 0 10H9" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M7 6L3 10l4 4" />
+                </svg>
+            </button>
+        `;
+    }
+
     private renderSaveButton() {
         if (!this.hasChanges) return nothing;
 
@@ -705,10 +747,13 @@ export class Toolbar extends ScmsElement {
                         ${this.renderTemplateMenu()}
                     </div>
 
-                    <!-- Right: Save + Sign Out + Admin + Help (separated) -->
+                    <!-- Right: Undo + Content Viewer + Save + Sign Out + Admin + Help -->
                     <div class="flex items-center">
-                        ${this.renderSaveButton()}
+                        ${this.renderUndoButton()}
                         ${this.renderContentViewerButton()}
+                        ${this.hasChanges
+                            ? html`<span class="mx-3">${this.renderSaveButton()}</span>`
+                            : nothing}
                         ${this.mockAuth
                             ? nothing
                             : html`<div
@@ -1095,9 +1140,9 @@ export class Toolbar extends ScmsElement {
                         ${this.hasChanges ? this.renderSaveButton() : nothing}
                     </div>
 
-                    <!-- Center: Element badge -->
-                    <div class="flex items-center justify-center">
-                        ${this.renderActiveElement()}
+                    <!-- Center: Undo -->
+                    <div class="flex items-center justify-center" @click=${(e: Event) => e.stopPropagation()}>
+                        ${this.renderUndoButton()}
                     </div>
 
                     <!-- Content Viewer + Help (right) -->

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -708,19 +708,19 @@ export class Toolbar extends ScmsElement {
                     <!-- Right: Save + Sign Out + Admin + Help (separated) -->
                     <div class="flex items-center">
                         ${this.renderSaveButton()}
+                        ${this.renderContentViewerButton()}
                         ${this.mockAuth
                             ? nothing
                             : html`<div
-                                  class="ml-6 pl-6 border-l border-gray-200 flex items-center"
+                                  class="ml-1 pl-3 border-l border-gray-200 flex items-center"
                               >
                                   ${this.renderSignOutButton()}
                                   ${this.denyAppGui
                                       ? nothing
-                                      : html`<span class="mx-2 text-gray-300">|</span>
-                                            ${this.renderAdminLink()}`}
+                                      : html`<span class="ml-2">${this.renderAdminLink()}</span>`}
                               </div>`}
                         <div class="ml-3 flex items-center gap-1">
-                            ${this.renderContentViewerButton()} ${this.renderHelpButton()}
+                            ${this.renderHelpButton()}
                         </div>
                     </div>
                 </div>

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -628,24 +628,9 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderActiveElement() {
-        // Show element badge if an element is active
-        if (this.activeElement) {
-            return html`<scms-element-badge
-                element-id=${this.activeElement}
-                element-type=${this.activeElementType || ""}
-            ></scms-element-badge>`;
-        }
-
-        // Show instance badge if only an instance is selected (no element)
-        if (this.templateId && this.instanceIndex !== null && this.instanceCount !== null) {
-            return html`<scms-instance-badge
-                instance-index=${this.instanceIndex}
-                instance-count=${this.instanceCount}
-            ></scms-instance-badge>`;
-        }
-
-        // No element or instance selected
-        return html`<span class="text-xs text-gray-400 italic">No element selected</span>`;
+        // Hidden for now — badge was too technical and confusing users.
+        // TODO: find a better way to display active element/instance details.
+        return nothing;
     }
 
     private renderDesktop() {

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -12,7 +12,7 @@
 import { html, css, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { unsafeSVG } from "lit/directives/unsafe-svg.js";
-import { CircleHelp, ChevronUp, ChevronDown, Ellipsis, Layers, Plus, Trash2 } from "lucide-static";
+import { CircleHelp, ChevronUp, ChevronDown, Ellipsis, Layers, Plus, ScanEye, Trash2 } from "lucide-static";
 import { ScmsElement } from "./base.js";
 import type { EditorMode } from "./mode-toggle.js";
 import "./mode-toggle.js";
@@ -73,6 +73,12 @@ export class Toolbar extends ScmsElement {
 
     @property({ type: Boolean, attribute: "structure-mismatch" })
     structureMismatch = false;
+
+    @property({ type: Boolean, attribute: "content-viewer-active" })
+    contentViewerActive = false;
+
+    @property({ type: Number, attribute: "hidden-element-count" })
+    hiddenElementCount = 0;
 
     @property({ type: Boolean, reflect: true })
     expanded = false;
@@ -343,6 +349,25 @@ export class Toolbar extends ScmsElement {
         );
     }
 
+    private handleContentViewerToggle() {
+        this.dispatchEvent(
+            new CustomEvent("content-viewer-toggle", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private handleShowHiddenElements(e: Event) {
+        e.stopPropagation();
+        this.dispatchEvent(
+            new CustomEvent("show-hidden-elements", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
     private handleAddInstance() {
         this.dispatchEvent(
             new CustomEvent("add-instance", {
@@ -594,6 +619,37 @@ export class Toolbar extends ScmsElement {
         `;
     }
 
+    private renderContentViewerButton() {
+        // Only show in editing mode (not viewer or when warning/readOnly)
+        if (this.warning || this.readOnly) return nothing;
+
+        const buttonClass = this.contentViewerActive
+            ? "w-8 h-8 flex items-center justify-center text-red-600 bg-red-50 rounded-full transition-colors [&>svg]:w-5 [&>svg]:h-5 relative"
+            : "w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors [&>svg]:w-5 [&>svg]:h-5 relative";
+
+        return html`
+            <button
+                class=${buttonClass}
+                @click=${this.handleContentViewerToggle}
+                title="Content Viewer"
+                aria-label="Content Viewer"
+                aria-pressed=${this.contentViewerActive}
+            >
+                ${unsafeSVG(ScanEye)}
+                ${this.contentViewerActive && this.hiddenElementCount > 0
+                    ? html`<button
+                          class="absolute -top-1.5 -right-1.5 min-w-[18px] h-[18px] px-1 flex items-center justify-center bg-orange-500 text-white text-[10px] font-bold rounded-full leading-none"
+                          @click=${this.handleShowHiddenElements}
+                          title="${this.hiddenElementCount} hidden element${this.hiddenElementCount === 1 ? "" : "s"}"
+                          aria-label="Show hidden elements"
+                      >
+                          ${this.hiddenElementCount}
+                      </button>`
+                    : nothing}
+            </button>
+        `;
+    }
+
     private renderHelpButton() {
         return html`
             <button
@@ -663,7 +719,9 @@ export class Toolbar extends ScmsElement {
                                       : html`<span class="mx-2 text-gray-300">|</span>
                                             ${this.renderAdminLink()}`}
                               </div>`}
-                        <div class="ml-3">${this.renderHelpButton()}</div>
+                        <div class="ml-3 flex items-center gap-1">
+                            ${this.renderContentViewerButton()} ${this.renderHelpButton()}
+                        </div>
                     </div>
                 </div>
             </div>
@@ -1042,12 +1100,12 @@ export class Toolbar extends ScmsElement {
                         ${this.renderActiveElement()}
                     </div>
 
-                    <!-- Help (right) -->
+                    <!-- Content Viewer + Help (right) -->
                     <div
-                        class="flex items-center w-16 justify-end"
+                        class="flex items-center w-20 justify-end gap-1"
                         @click=${(e: Event) => e.stopPropagation()}
                     >
-                        ${this.renderHelpButton()}
+                        ${this.renderContentViewerButton()} ${this.renderHelpButton()}
                     </div>
                 </button>
 

--- a/src/components/type-icon.ts
+++ b/src/components/type-icon.ts
@@ -1,0 +1,78 @@
+/**
+ * Shared type icon rendering utility
+ *
+ * Returns SVG icons for editable element types: text, html, image, link.
+ * Used by element-badge and content-viewer-badge components.
+ */
+
+import { html, type TemplateResult } from "lit";
+
+export function renderTypeIcon(
+    elementType: string | null,
+    iconClass = "w-3.5 h-3.5 text-gray-500 shrink-0",
+    iconClassAdjusted = "w-3.5 h-3.5 text-gray-500 shrink-0 -translate-y-px",
+): TemplateResult | null {
+    switch (elementType) {
+        case "text":
+            return html`
+                <svg
+                    class=${iconClassAdjusted}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 4h16M12 4v16"
+                    />
+                </svg>
+            `;
+        case "html":
+            return html`
+                <svg
+                    class=${iconClassAdjusted}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                    />
+                </svg>
+            `;
+        case "image":
+            return html`
+                <svg class=${iconClass} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
+                </svg>
+            `;
+        case "link":
+            return html`
+                <svg
+                    class=${iconClassAdjusted}
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                    />
+                </svg>
+            `;
+        default:
+            return null;
+    }
+}

--- a/src/lazy/content-viewer-manager.ts
+++ b/src/lazy/content-viewer-manager.ts
@@ -1,0 +1,390 @@
+/**
+ * ContentViewerManager - Manages the content viewer overlay
+ *
+ * Responsible for:
+ * - Toggling floating badges over all editable elements
+ * - Classifying elements as visible or hidden
+ * - Positioning badges and updating on scroll/resize
+ * - Showing a panel for hidden/off-screen elements
+ */
+
+import type { Logger } from "loganite";
+import type { EditorState } from "./state.js";
+import type { ContentViewerBadge } from "../components/content-viewer-badge.js";
+import type { ContentViewerPanel, HiddenElementInfo } from "../components/content-viewer-panel.js";
+
+/**
+ * Helpers that ContentViewerManager needs from EditorController
+ */
+export interface ContentViewerHelpers {
+    selectAndEdit: (key: string, element: HTMLElement) => void;
+    scrollToElement: (element: HTMLElement, delay?: number) => void;
+    updateToolbarContentViewer: (active: boolean, hiddenCount: number) => void;
+}
+
+interface BadgeInfo {
+    badge: ContentViewerBadge;
+    element: HTMLElement;
+    key: string;
+}
+
+type ElementVisibility =
+    | { visible: true }
+    | { visible: false; reason: string };
+
+export class ContentViewerManager {
+    private active = false;
+    private badges: BadgeInfo[] = [];
+    private panel: ContentViewerPanel | null = null;
+    private panelCloseHandler: ((e: MouseEvent) => void) | null = null;
+    private hiddenElements: HiddenElementInfo[] = [];
+    private rafId: number | null = null;
+    private scrollHandler: (() => void) | null = null;
+    private resizeHandler: (() => void) | null = null;
+    private lastClassifyTime = 0;
+    private readonly RECLASSIFY_INTERVAL = 500;
+
+    constructor(
+        private state: EditorState,
+        private log: Logger,
+        private helpers: ContentViewerHelpers,
+    ) {}
+
+    get isActive(): boolean {
+        return this.active;
+    }
+
+    toggle(): void {
+        if (this.active) {
+            this.deactivate();
+        } else {
+            this.activate();
+        }
+    }
+
+    activate(): void {
+        if (this.active) return;
+        this.active = true;
+        this.log.trace("Content viewer activated");
+
+        this.createBadges();
+        this.updatePositions();
+        this.registerListeners();
+        this.helpers.updateToolbarContentViewer(true, this.hiddenElements.length);
+    }
+
+    deactivate(): void {
+        if (!this.active) return;
+        this.active = false;
+        this.log.trace("Content viewer deactivated");
+
+        this.destroyBadges();
+        this.closeHiddenPanel();
+        this.unregisterListeners();
+        this.helpers.updateToolbarContentViewer(false, 0);
+    }
+
+    showHiddenPanel(): void {
+        if (!this.active) return;
+
+        // Toggle off if already open
+        if (this.panel) {
+            this.closeHiddenPanel();
+            return;
+        }
+
+        const panel = document.createElement("scms-content-viewer-panel") as ContentViewerPanel;
+        panel.hiddenElements = this.hiddenElements;
+
+        panel.addEventListener("close", () => this.closeHiddenPanel());
+        panel.addEventListener("hidden-element-click", (e: Event) => {
+            const key = (e as CustomEvent<{ key: string }>).detail.key;
+            this.handleHiddenElementClick(key);
+        });
+
+        document.body.appendChild(panel);
+        this.panel = panel;
+
+        // Close on click outside (after short delay to avoid immediate close)
+        this.panelCloseHandler = (e: MouseEvent) => {
+            if (this.panel && !this.panel.contains(e.target as Node)) {
+                this.closeHiddenPanel();
+            }
+        };
+        setTimeout(() => {
+            if (this.panelCloseHandler) {
+                document.addEventListener("click", this.panelCloseHandler);
+            }
+        }, 0);
+    }
+
+    private closeHiddenPanel(): void {
+        if (this.panel) {
+            this.panel.remove();
+            this.panel = null;
+        }
+        if (this.panelCloseHandler) {
+            document.removeEventListener("click", this.panelCloseHandler);
+            this.panelCloseHandler = null;
+        }
+    }
+
+    private handleHiddenElementClick(key: string): void {
+        const infos = this.state.editableElements.get(key);
+        if (!infos || infos.length === 0) return;
+
+        const element = infos[0].element;
+
+        // Scroll into view first, then select after deactivating overlay
+        this.helpers.scrollToElement(element, 0);
+        this.deactivate();
+        this.helpers.selectAndEdit(key, element);
+    }
+
+    private handleBadgeClick(key: string): void {
+        const infos = this.state.editableElements.get(key);
+        if (!infos || infos.length === 0) return;
+
+        // Find the element corresponding to this badge
+        const element = infos[0].element;
+
+        this.deactivate();
+        this.helpers.selectAndEdit(key, element);
+    }
+
+    private createBadges(): void {
+        this.badges = [];
+        this.hiddenElements = [];
+
+        this.state.editableElements.forEach((infos, key) => {
+            const elementType = this.state.editableTypes.get(key) || "html";
+
+            for (const info of infos) {
+                if (!info.element.isConnected) continue;
+
+                const visibility = this.classifyElement(info.element);
+
+                if (visibility.visible) {
+                    const badge = document.createElement(
+                        "scms-content-viewer-badge",
+                    ) as ContentViewerBadge;
+                    badge.elementKey = key;
+                    badge.elementId = info.elementId;
+                    badge.elementType = elementType;
+
+                    badge.addEventListener("badge-click", (e: Event) => {
+                        const clickedKey = (e as CustomEvent<{ key: string }>).detail.key;
+                        this.handleBadgeClick(clickedKey);
+                    });
+
+                    document.body.appendChild(badge);
+                    this.badges.push({ badge, element: info.element, key });
+                } else {
+                    this.hiddenElements.push({
+                        key,
+                        elementId: info.elementId,
+                        elementType,
+                        reason: visibility.reason,
+                    });
+                }
+            }
+        });
+    }
+
+    private classifyElement(element: HTMLElement): ElementVisibility {
+        // Check display:none (offsetParent is null for non-fixed/non-sticky elements)
+        const style = getComputedStyle(element);
+        if (
+            element.offsetParent === null &&
+            style.position !== "fixed" &&
+            style.position !== "sticky"
+        ) {
+            return { visible: false, reason: "hidden" };
+        }
+
+        // Check visibility:hidden
+        if (style.visibility === "hidden") {
+            return { visible: false, reason: "hidden" };
+        }
+
+        // Check zero dimensions
+        const rect = element.getBoundingClientRect();
+        if (rect.width === 0 && rect.height === 0) {
+            return { visible: false, reason: "zero size" };
+        }
+
+        // Check completely off-screen
+        if (
+            rect.bottom < 0 ||
+            rect.top > window.innerHeight ||
+            rect.right < 0 ||
+            rect.left > window.innerWidth
+        ) {
+            return { visible: false, reason: "off-screen" };
+        }
+
+        return { visible: true };
+    }
+
+    private updatePositions(): void {
+        if (!this.active) return;
+
+        const now = Date.now();
+        const shouldReclassify = now - this.lastClassifyTime > this.RECLASSIFY_INTERVAL;
+
+        if (shouldReclassify) {
+            this.lastClassifyTime = now;
+            this.reclassifyElements();
+        }
+
+        // Position all visible badges
+        for (const { badge, element } of this.badges) {
+            if (!element.isConnected) {
+                badge.style.display = "none";
+                continue;
+            }
+
+            const rect = element.getBoundingClientRect();
+
+            // Hide badges for elements currently off-screen
+            if (
+                rect.bottom < 0 ||
+                rect.top > window.innerHeight ||
+                rect.right < 0 ||
+                rect.left > window.innerWidth
+            ) {
+                badge.style.display = "none";
+                continue;
+            }
+
+            badge.style.display = "";
+            badge.style.top = `${Math.max(0, rect.top + 4)}px`;
+            badge.style.left = `${Math.max(0, rect.left + 4)}px`;
+        }
+
+        this.rafId = requestAnimationFrame(() => this.updatePositions());
+    }
+
+    private reclassifyElements(): void {
+        // Rebuild badges and hidden list from scratch
+        const oldBadges = this.badges;
+        const oldHidden = this.hiddenElements;
+
+        // Track which elements currently have badges (by key + element ref)
+        const existingBadgeMap = new Map<string, Map<HTMLElement, ContentViewerBadge>>();
+        for (const { key, element, badge } of oldBadges) {
+            if (!existingBadgeMap.has(key)) {
+                existingBadgeMap.set(key, new Map());
+            }
+            existingBadgeMap.get(key)!.set(element, badge);
+        }
+
+        this.badges = [];
+        this.hiddenElements = [];
+
+        this.state.editableElements.forEach((infos, key) => {
+            const elementType = this.state.editableTypes.get(key) || "html";
+
+            for (const info of infos) {
+                if (!info.element.isConnected) continue;
+
+                const visibility = this.classifyElement(info.element);
+
+                if (visibility.visible) {
+                    // Reuse existing badge if available
+                    const existingBadge = existingBadgeMap.get(key)?.get(info.element);
+                    if (existingBadge) {
+                        this.badges.push({
+                            badge: existingBadge,
+                            element: info.element,
+                            key,
+                        });
+                        existingBadgeMap.get(key)!.delete(info.element);
+                    } else {
+                        // Create new badge
+                        const badge = document.createElement(
+                            "scms-content-viewer-badge",
+                        ) as ContentViewerBadge;
+                        badge.elementKey = key;
+                        badge.elementId = info.elementId;
+                        badge.elementType = elementType;
+
+                        badge.addEventListener("badge-click", (e: Event) => {
+                            const clickedKey = (e as CustomEvent<{ key: string }>).detail.key;
+                            this.handleBadgeClick(clickedKey);
+                        });
+
+                        document.body.appendChild(badge);
+                        this.badges.push({ badge, element: info.element, key });
+                    }
+                } else {
+                    this.hiddenElements.push({
+                        key,
+                        elementId: info.elementId,
+                        elementType,
+                        reason: visibility.reason,
+                    });
+                }
+            }
+        });
+
+        // Remove badges that are no longer needed
+        for (const [, elementMap] of existingBadgeMap) {
+            for (const [, badge] of elementMap) {
+                badge.remove();
+            }
+        }
+
+        // Update hidden panel if open
+        if (this.panel) {
+            this.panel.hiddenElements = [...this.hiddenElements];
+        }
+
+        // Check if hidden count changed
+        if (this.hiddenElements.length !== oldHidden.length) {
+            this.helpers.updateToolbarContentViewer(true, this.hiddenElements.length);
+        }
+    }
+
+    private destroyBadges(): void {
+        for (const { badge } of this.badges) {
+            badge.remove();
+        }
+        this.badges = [];
+        this.hiddenElements = [];
+    }
+
+    private registerListeners(): void {
+        let ticking = false;
+        this.scrollHandler = () => {
+            if (!ticking) {
+                ticking = true;
+                requestAnimationFrame(() => {
+                    ticking = false;
+                });
+            }
+        };
+        this.resizeHandler = () => {
+            // Force reclassification on resize
+            this.lastClassifyTime = 0;
+        };
+
+        window.addEventListener("scroll", this.scrollHandler, { passive: true });
+        window.addEventListener("resize", this.resizeHandler, { passive: true });
+    }
+
+    private unregisterListeners(): void {
+        if (this.scrollHandler) {
+            window.removeEventListener("scroll", this.scrollHandler);
+            this.scrollHandler = null;
+        }
+        if (this.resizeHandler) {
+            window.removeEventListener("resize", this.resizeHandler);
+            this.resizeHandler = null;
+        }
+        if (this.rafId !== null) {
+            cancelAnimationFrame(this.rafId);
+            this.rafId = null;
+        }
+    }
+}

--- a/src/lazy/content-viewer-manager.ts
+++ b/src/lazy/content-viewer-manager.ts
@@ -28,9 +28,7 @@ interface BadgeInfo {
     key: string;
 }
 
-type ElementVisibility =
-    | { visible: true }
-    | { visible: false; reason: string };
+type ElementVisibility = { visible: true } | { visible: false; reason: string };
 
 export class ContentViewerManager {
     private active = false;

--- a/src/lazy/draft-manager.ts
+++ b/src/lazy/draft-manager.ts
@@ -48,13 +48,7 @@ export class DraftManager {
      * Get keys that are pending deletion (in savedContentKeys but not in currentContent)
      */
     getPendingDeletes(): string[] {
-        const deletes: string[] = [];
-        this.state.savedContentKeys.forEach((key) => {
-            if (!this.state.currentContent.has(key)) {
-                deletes.push(key);
-            }
-        });
-        return deletes;
+        return Array.from(this.state.pendingDeletes);
     }
 
     /**
@@ -233,6 +227,7 @@ export class DraftManager {
         // Step 3: Apply deletes
         for (const key of draft.deleted) {
             this.state.currentContent.delete(key);
+            this.state.pendingDeletes.add(key);
         }
 
         this.log.info("Draft restored successfully");
@@ -430,6 +425,7 @@ export class DraftManager {
                     this.state.editableElements.delete(key);
                     this.state.editableTypes.delete(key);
                     this.state.currentContent.delete(key);
+                    this.state.pendingDeletes.add(key);
                 }
             }
         });

--- a/src/lazy/draft-manager.ts
+++ b/src/lazy/draft-manager.ts
@@ -34,6 +34,8 @@ export interface DraftManagerHelpers {
         instanceId: string,
         groupId: string | null,
     ) => void;
+    addInstanceWithId: (templateId: string, instanceId: string) => HTMLElement | null;
+    reorderInstances: (templateId: string, targetOrder: string[]) => void;
 }
 
 export class DraftManager {
@@ -322,60 +324,10 @@ export class DraftManager {
     }
 
     /**
-     * Add a template instance with a specific ID (for draft restoration).
-     * Similar to addInstance() but uses a provided ID instead of generating one.
+     * Add a template instance with a specific ID (delegates to TemplateManager).
      */
     private addInstanceWithId(templateId: string, instanceId: string): void {
-        const templateInfo = this.state.templates.get(templateId);
-        if (!templateInfo) {
-            this.log.error("Template not found", { templateId });
-            return;
-        }
-
-        const { container, templateHtml, groupId } = templateInfo;
-
-        // Create new instance from original template HTML
-        const tempDiv = document.createElement("div");
-        tempDiv.innerHTML = templateHtml;
-        const clone = tempDiv.firstElementChild as HTMLElement;
-        if (!clone) {
-            this.log.error("Failed to create clone from template HTML");
-            return;
-        }
-
-        clone.setAttribute("data-scms-instance", instanceId);
-        clone.removeAttribute("data-scms-template");
-
-        // Add placeholder to image elements without src
-        clone.querySelectorAll<HTMLImageElement>("img[data-scms-image]").forEach((img) => {
-            if (!img.src) {
-                img.src = IMAGE_PLACEHOLDER_DATA_URI;
-            }
-        });
-        if (
-            clone instanceof HTMLImageElement &&
-            clone.hasAttribute("data-scms-image") &&
-            !clone.src
-        ) {
-            clone.src = IMAGE_PLACEHOLDER_DATA_URI;
-        }
-
-        // Insert at end of container (will be reordered later)
-        const addButton = this.state.templateAddButtons.get(templateId);
-        if (addButton && addButton.parentElement === container) {
-            container.insertBefore(clone, addButton);
-        } else {
-            container.appendChild(clone);
-        }
-
-        // Update instance tracking
-        templateInfo.instanceIds.push(instanceId);
-        templateInfo.instanceCount = templateInfo.instanceIds.length;
-
-        // Register editable elements in the new instance
-        this.helpers.registerInstanceElements(clone, templateId, instanceId, groupId);
-
-        this.log.debug("Added template instance from draft", { templateId, instanceId });
+        this.helpers.addInstanceWithId(templateId, instanceId);
     }
 
     /**
@@ -438,38 +390,9 @@ export class DraftManager {
     }
 
     /**
-     * Reorder template instances to match a specific order.
+     * Reorder template instances to match a specific order (delegates to TemplateManager).
      */
     private reorderInstances(templateId: string, targetOrder: string[]): void {
-        const templateInfo = this.state.templates.get(templateId);
-        if (!templateInfo) return;
-
-        const { container } = templateInfo;
-
-        // Get current instance elements
-        const instanceElements = new Map<string, HTMLElement>();
-        container.querySelectorAll<HTMLElement>("[data-scms-instance]").forEach((el) => {
-            const id = el.getAttribute("data-scms-instance");
-            if (id) instanceElements.set(id, el);
-        });
-
-        // Find insertion point (before add button or at end)
-        const addButton = this.state.templateAddButtons.get(templateId);
-        const insertBefore = addButton?.parentElement === container ? addButton : null;
-
-        // Reorder by removing and re-inserting in correct order
-        for (const instanceId of targetOrder) {
-            const element = instanceElements.get(instanceId);
-            if (element) {
-                if (insertBefore) {
-                    container.insertBefore(element, insertBefore);
-                } else {
-                    container.appendChild(element);
-                }
-            }
-        }
-
-        // Update templateInfo.instanceIds to match
-        templateInfo.instanceIds = targetOrder.filter((id) => instanceElements.has(id));
+        this.helpers.reorderInstances(templateId, targetOrder);
     }
 }

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -73,6 +73,8 @@ export class EditingManager {
         ) as HTMLElement | null;
         if (parentInstance) {
             this.selectInstance(parentInstance);
+        } else {
+            this.deselectInstance();
         }
 
         // Add selection classes

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -87,6 +87,7 @@ import { ContentViewerManager } from "./content-viewer-manager.js";
 import { injectEditStyles } from "./styles.js";
 import { normalizeWhitespace, normalizeHtmlWhitespace } from "./normalize.js";
 import { TourManager, getTourDefinitions } from "./tours/index.js";
+import { UndoManager } from "./undo-manager.js";
 
 // Toolbar height constants
 const TOOLBAR_HEIGHT_DESKTOP = 48;
@@ -137,6 +138,7 @@ class EditorController {
     private authManager: AuthManager;
     private tourManager: TourManager;
     private contentViewerManager: ContentViewerManager;
+    private undoManager: UndoManager;
     // Reverse lookup: element -> key (for click handling) - WeakMap can't be reactive
     private elementToKey: WeakMap<HTMLElement, string> = new WeakMap();
     // Double-tap delay constant
@@ -211,6 +213,9 @@ class EditorController {
         // Initialize reactive state
         this.state = createEditorState();
 
+        // Initialize undo manager
+        this.undoManager = new UndoManager(this.log, () => this.updateToolbarUndoState());
+
         // Initialize content manager
         this.contentManager = new ContentManager(this.state);
 
@@ -234,7 +239,7 @@ class EditorController {
         );
 
         // Initialize template manager
-        this.templateManager = new TemplateManager(this.state, this.log, this.contentManager, {
+        this.templateManager = new TemplateManager(this.state, this.log, this.contentManager, this.undoManager, {
             getGroupIdFromElement: this.getGroupIdFromElement.bind(this),
             getEditableInfo: this.getEditableInfo.bind(this),
             getStorageContext: this.getStorageContext.bind(this),
@@ -263,6 +268,10 @@ class EditorController {
                     instanceId,
                     groupId,
                 ),
+            addInstanceWithId: (templateId, instanceId) =>
+                this.templateManager.addInstanceWithId(templateId, instanceId),
+            reorderInstances: (templateId, targetOrder) =>
+                this.templateManager.reorderInstances(templateId, targetOrder),
         });
 
         // Initialize save manager
@@ -986,6 +995,16 @@ class EditorController {
             this.contentViewerManager.showHiddenPanel();
         });
 
+        toolbar.addEventListener("undo", () => {
+            this.undoManager.undo();
+            this.saveManager.updateToolbarHasChanges();
+        });
+
+        toolbar.addEventListener("redo", () => {
+            this.undoManager.redo();
+            this.saveManager.updateToolbarHasChanges();
+        });
+
         document.body.appendChild(toolbar);
         this.state.toolbar = toolbar;
 
@@ -995,6 +1014,13 @@ class EditorController {
         // Add body padding to prevent content overlap
         this.updateBodyPadding();
         window.addEventListener("resize", this.updateBodyPadding);
+    }
+
+    private updateToolbarUndoState(): void {
+        if (this.state.toolbar) {
+            this.state.toolbar.canUndo = this.undoManager.canUndo;
+            this.state.toolbar.canRedo = this.undoManager.canRedo;
+        }
     }
 
     private updateBodyPadding = (): void => {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -70,6 +70,8 @@ import "../components/accessibility-modal.js";
 import "../components/attributes-modal.js";
 import "../components/media-manager-modal.js";
 import "../components/help-panel.js";
+import "../components/content-viewer-badge.js";
+import "../components/content-viewer-panel.js";
 import type { Toolbar } from "../components/toolbar.js";
 import type { HelpPanel } from "../components/help-panel.js";
 import { createEditorState, type EditorState, type EditableElementInfo } from "./state.js";
@@ -81,6 +83,7 @@ import { ModalManager } from "./modal-manager.js";
 import { SaveManager } from "./save-manager.js";
 import { AuthManager } from "./auth-manager.js";
 import { AuthBridge } from "./auth-bridge.js";
+import { ContentViewerManager } from "./content-viewer-manager.js";
 import { injectEditStyles } from "./styles.js";
 import { normalizeWhitespace, normalizeHtmlWhitespace } from "./normalize.js";
 import { TourManager, getTourDefinitions } from "./tours/index.js";
@@ -133,6 +136,7 @@ class EditorController {
     private saveManager: SaveManager;
     private authManager: AuthManager;
     private tourManager: TourManager;
+    private contentViewerManager: ContentViewerManager;
     // Reverse lookup: element -> key (for click handling) - WeakMap can't be reactive
     private elementToKey: WeakMap<HTMLElement, string> = new WeakMap();
     // Double-tap delay constant
@@ -327,6 +331,20 @@ class EditorController {
 
         // Initialize tour manager
         this.tourManager = new TourManager();
+
+        // Initialize content viewer manager
+        this.contentViewerManager = new ContentViewerManager(this.state, this.log, {
+            selectAndEdit: (key, element) => {
+                this.editingManager.startEditing(key, element);
+            },
+            scrollToElement: this.scrollToElement.bind(this),
+            updateToolbarContentViewer: (active, hiddenCount) => {
+                if (this.state.toolbar) {
+                    this.state.toolbar.contentViewerActive = active;
+                    this.state.toolbar.hiddenElementCount = hiddenCount;
+                }
+            },
+        });
     }
 
     /**
@@ -866,6 +884,7 @@ class EditorController {
         this.editingManager.deselectInstance();
         this.editingManager.deselectElement();
         this.editingManager.stopEditing();
+        this.contentViewerManager.deactivate();
     }
 
     private showToolbar(): void {
@@ -957,6 +976,14 @@ class EditorController {
 
         toolbar.addEventListener("help", () => {
             this.handleHelp();
+        });
+
+        toolbar.addEventListener("content-viewer-toggle", () => {
+            this.contentViewerManager.toggle();
+        });
+
+        toolbar.addEventListener("show-hidden-elements", () => {
+            this.contentViewerManager.showHiddenPanel();
         });
 
         document.body.appendChild(toolbar);

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -239,20 +239,26 @@ class EditorController {
         );
 
         // Initialize template manager
-        this.templateManager = new TemplateManager(this.state, this.log, this.contentManager, this.undoManager, {
-            getGroupIdFromElement: this.getGroupIdFromElement.bind(this),
-            getEditableInfo: this.getEditableInfo.bind(this),
-            getStorageContext: this.getStorageContext.bind(this),
-            buildStorageKey: this.buildStorageKey.bind(this),
-            normalizeDomWhitespace: this.normalizeDomWhitespace.bind(this),
-            isInstanceAlsoEditable: this.isInstanceAlsoEditable.bind(this),
-            setupElementClickHandler: this.setupElementClickHandler.bind(this),
-            selectInstance: (el) => this.editingManager.selectInstance(el),
-            stopEditing: () => this.editingManager.stopEditing(),
-            updateToolbarHasChanges: () => this.saveManager.updateToolbarHasChanges(),
-            getElementToKeyMap: () => this.elementToKey,
-            scrollToElement: this.scrollToElement.bind(this),
-        });
+        this.templateManager = new TemplateManager(
+            this.state,
+            this.log,
+            this.contentManager,
+            this.undoManager,
+            {
+                getGroupIdFromElement: this.getGroupIdFromElement.bind(this),
+                getEditableInfo: this.getEditableInfo.bind(this),
+                getStorageContext: this.getStorageContext.bind(this),
+                buildStorageKey: this.buildStorageKey.bind(this),
+                normalizeDomWhitespace: this.normalizeDomWhitespace.bind(this),
+                isInstanceAlsoEditable: this.isInstanceAlsoEditable.bind(this),
+                setupElementClickHandler: this.setupElementClickHandler.bind(this),
+                selectInstance: (el) => this.editingManager.selectInstance(el),
+                stopEditing: () => this.editingManager.stopEditing(),
+                updateToolbarHasChanges: () => this.saveManager.updateToolbarHasChanges(),
+                getElementToKeyMap: () => this.elementToKey,
+                scrollToElement: this.scrollToElement.bind(this),
+            },
+        );
 
         // Initialize draft manager
         this.draftManager = new DraftManager(this.state, this.log, this._draftStorageKey, {

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -441,6 +441,9 @@ export class ModalManager {
             for (const info of infos) {
                 applyAttributesToElement(info.element, e.detail.attributes);
             }
+            // Update currentContent so dirty detection and drafts capture the change
+            const content = this.contentManager.getElementContent(key, primaryInfo);
+            this.contentManager.setContent(key, content);
             this.closeModal("seoModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("SEO attributes applied", {
@@ -500,6 +503,9 @@ export class ModalManager {
             for (const info of infos) {
                 applyAttributesToElement(info.element, e.detail.attributes);
             }
+            // Update currentContent so dirty detection and drafts capture the change
+            const content = this.contentManager.getElementContent(key, primaryInfo);
+            this.contentManager.setContent(key, content);
             this.closeModal("accessibilityModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("Accessibility attributes applied", {
@@ -556,6 +562,9 @@ export class ModalManager {
             for (const info of infos) {
                 applyAttributesToElement(info.element, e.detail.attributes);
             }
+            // Update currentContent so dirty detection and drafts capture the change
+            const content = this.contentManager.getElementContent(key, primaryInfo);
+            this.contentManager.setContent(key, content);
             this.closeModal("attributesModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("Custom attributes applied", {

--- a/src/lazy/save-manager.ts
+++ b/src/lazy/save-manager.ts
@@ -404,8 +404,8 @@ export class SaveManager {
                 }
 
                 // Process deleted grouped elements from response
-                for (const [groupId, elementIds] of Object.entries(result.deleted?.groups ?? {})) {
-                    for (const elementId of elementIds) {
+                for (const [groupId, group] of Object.entries(result.deleted?.groups ?? {})) {
+                    for (const elementId of group.elements) {
                         const key = `${groupId}:${elementId}`;
                         this.state.originalContent.delete(key);
                         this.state.savedContentKeys.delete(key);

--- a/src/lazy/save-manager.ts
+++ b/src/lazy/save-manager.ts
@@ -400,6 +400,7 @@ export class SaveManager {
                     const key = elementId;
                     this.state.originalContent.delete(key);
                     this.state.savedContentKeys.delete(key);
+                    this.state.pendingDeletes.delete(key);
                     deleted.push(key);
                 }
 
@@ -409,6 +410,7 @@ export class SaveManager {
                         const key = `${groupId}:${elementId}`;
                         this.state.originalContent.delete(key);
                         this.state.savedContentKeys.delete(key);
+                        this.state.pendingDeletes.delete(key);
                         deleted.push(key);
                     }
                 }

--- a/src/lazy/save-manager.ts
+++ b/src/lazy/save-manager.ts
@@ -237,10 +237,24 @@ export class SaveManager {
         const templatesWithOrderChanges = this.templateManager.getTemplatesWithOrderChanges();
         const hasOrderChanges = templatesWithOrderChanges.length > 0;
 
+        // Also include templates that have dirty elements (not just order changes),
+        // so unsaved sibling fields are persisted alongside the edited field.
+        // Fixes: https://github.com/streamlinedcms/client-sdk/issues/70
+        const templatesWithDirtyElements = new Set<string>();
+        for (const [, { info }] of dirtyElements) {
+            if (info.templateId) {
+                templatesWithDirtyElements.add(info.templateId);
+            }
+        }
+        const templatesNeedingUnsavedElements = [
+            ...new Set([...templatesWithOrderChanges, ...templatesWithDirtyElements]),
+        ];
+
         // Get unsaved template elements (HTML-derived items that need to be persisted
-        // when the template order changes)
-        const unsavedTemplateElements =
-            this.contentManager.getUnsavedTemplateElements(templatesWithOrderChanges);
+        // when the template has order changes or dirty elements)
+        const unsavedTemplateElements = this.contentManager.getUnsavedTemplateElements(
+            templatesNeedingUnsavedElements,
+        );
 
         if (dirtyElements.size === 0 && pendingDeletes.length === 0 && !hasOrderChanges) {
             return;

--- a/src/lazy/state.ts
+++ b/src/lazy/state.ts
@@ -62,6 +62,7 @@ export interface EditorState {
     originalContent: Map<string, string>;
     currentContent: Map<string, string>;
     savedContentKeys: Set<string>;
+    pendingDeletes: Set<string>;
     elementAttributes: Map<string, ElementAttributes>;
 
     // Selection & editing
@@ -112,6 +113,7 @@ export function createEditorState(): EditorState {
         originalContent: new Map(),
         currentContent: new Map(),
         savedContentKeys: new Set(),
+        pendingDeletes: new Set(),
         elementAttributes: new Map(),
 
         // Selection & editing

--- a/src/lazy/styles.ts
+++ b/src/lazy/styles.ts
@@ -96,6 +96,11 @@ export function injectEditStyles(): void {
             }
         }
 
+        [data-scms-instance].scms-instance-selected {
+            outline: 2px dashed #ef4444;
+            outline-offset: -2px;
+        }
+
         /* Touch devices: show when instance is selected */
         @media (hover: none) {
             [data-scms-instance].scms-instance-selected > .scms-instance-delete {

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -94,6 +94,7 @@ export class TemplateManager {
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
+            el.innerHTML = "";
         });
 
         // Replace all text nodes with empty strings

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -12,6 +12,7 @@ import type { Logger } from "loganite";
 import Sortable from "sortablejs";
 import type { EditorState, TemplateInfo, EditableElementInfo } from "./state.js";
 import type { ContentManager } from "./content-manager.js";
+import type { UndoManager } from "./undo-manager.js";
 import { EDITABLE_SELECTOR, IMAGE_PLACEHOLDER_DATA_URI, type EditableType } from "../types.js";
 
 /**
@@ -41,11 +42,13 @@ export interface TemplateManagerHelpers {
 
 export class TemplateManager {
     private instanceDeleteButtons = new WeakMap<HTMLElement, HTMLButtonElement>();
+    private _skipUndoPush = false;
 
     constructor(
         private state: EditorState,
         private log: Logger,
         private contentManager: ContentManager,
+        private undoManager: UndoManager,
         private helpers: TemplateManagerHelpers,
     ) {}
 
@@ -546,6 +549,96 @@ export class TemplateManager {
     }
 
     /**
+     * Add a template instance with a specific ID.
+     * Used by draft restoration and undo to recreate instances with known IDs.
+     */
+    addInstanceWithId(templateId: string, instanceId: string): HTMLElement | null {
+        const templateInfo = this.state.templates.get(templateId);
+        if (!templateInfo) {
+            this.log.error("Template not found", { templateId });
+            return null;
+        }
+
+        const { container, templateHtml, groupId } = templateInfo;
+
+        const tempDiv = document.createElement("div");
+        tempDiv.innerHTML = templateHtml;
+        const clone = tempDiv.firstElementChild as HTMLElement;
+        if (!clone) {
+            this.log.error("Failed to create clone from template HTML");
+            return null;
+        }
+
+        clone.setAttribute("data-scms-instance", instanceId);
+        clone.removeAttribute("data-scms-template");
+
+        // Add placeholder to image elements without src
+        clone.querySelectorAll<HTMLImageElement>("img[data-scms-image]").forEach((img) => {
+            if (!img.src) {
+                img.src = IMAGE_PLACEHOLDER_DATA_URI;
+            }
+        });
+        if (
+            clone instanceof HTMLImageElement &&
+            clone.hasAttribute("data-scms-image") &&
+            !clone.src
+        ) {
+            clone.src = IMAGE_PLACEHOLDER_DATA_URI;
+        }
+
+        // Insert at end of container (will be reordered later if needed)
+        const addButton = this.state.templateAddButtons.get(templateId);
+        if (addButton && addButton.parentElement === container) {
+            container.insertBefore(clone, addButton);
+        } else {
+            container.appendChild(clone);
+        }
+
+        // Update instance tracking
+        templateInfo.instanceIds.push(instanceId);
+        templateInfo.instanceCount = templateInfo.instanceIds.length;
+
+        // Register editable elements in the new instance
+        this.registerInstanceElements(clone, templateId, instanceId, groupId);
+
+        this.log.debug("Added template instance with ID", { templateId, instanceId });
+
+        return clone;
+    }
+
+    /**
+     * Reorder template instances in the DOM to match a target order.
+     */
+    reorderInstances(templateId: string, targetOrder: string[]): void {
+        const templateInfo = this.state.templates.get(templateId);
+        if (!templateInfo) return;
+
+        const { container } = templateInfo;
+
+        const instanceElements = new Map<string, HTMLElement>();
+        container.querySelectorAll<HTMLElement>("[data-scms-instance]").forEach((el) => {
+            const id = el.getAttribute("data-scms-instance");
+            if (id) instanceElements.set(id, el);
+        });
+
+        const addButton = this.state.templateAddButtons.get(templateId);
+        const insertBefore = addButton?.parentElement === container ? addButton : null;
+
+        for (const instId of targetOrder) {
+            const element = instanceElements.get(instId);
+            if (element) {
+                if (insertBefore) {
+                    container.insertBefore(element, insertBefore);
+                } else {
+                    container.appendChild(element);
+                }
+            }
+        }
+
+        templateInfo.instanceIds = targetOrder.filter((id) => instanceElements.has(id));
+    }
+
+    /**
      * Remove a template instance
      */
     async removeInstance(templateId: string, instanceId: string): Promise<void> {
@@ -589,6 +682,20 @@ export class TemplateManager {
             }
         });
 
+        // Capture state for undo before making changes
+        const contentEntries = new Map<string, string>();
+        for (const key of keysToDelete) {
+            const value = this.state.currentContent.get(key);
+            if (value !== undefined) {
+                contentEntries.set(key, value);
+            }
+        }
+        const orderKey = `${templateId}._order`;
+        const orderContentKey = templateInfo.groupId
+            ? `${templateInfo.groupId}:${orderKey}`
+            : orderKey;
+        const previousOrderValue = this.state.currentContent.get(orderContentKey) ?? "";
+
         // Stop editing if we're editing something in this instance
         if (this.state.editingKey && keysToDelete.includes(this.state.editingKey)) {
             this.helpers.stopEditing();
@@ -597,12 +704,10 @@ export class TemplateManager {
         // Remove from DOM
         instanceElement.remove();
 
-        // Update tracking - remove from currentContent to mark for deletion
-        // (deletion is derived from: key in originalContent but not in currentContent)
+        // Update tracking
         keysToDelete.forEach((key) => {
             const infos = this.state.editableElements.get(key);
             if (infos) {
-                // Remove elements that were in this instance
                 const remaining = infos.filter((info) => info.instanceId !== instanceId);
                 if (remaining.length > 0) {
                     this.state.editableElements.set(key, remaining);
@@ -627,6 +732,29 @@ export class TemplateManager {
 
         this.log.debug("Removed template instance", { templateId, instanceId });
 
+        // Push undo action (skip when called from redo)
+        if (!this._skipUndoPush) {
+            this.undoManager.push({
+                type: "remove-instance",
+                description: `Delete template instance`,
+                timestamp: Date.now(),
+                undo: () => {
+                    this.restoreInstance(
+                        templateId,
+                        instanceId,
+                        contentEntries,
+                        orderContentKey,
+                        previousOrderValue,
+                    );
+                },
+                redo: () => {
+                    this._skipUndoPush = true;
+                    this.removeInstance(templateId, instanceId);
+                    this._skipUndoPush = false;
+                },
+            });
+        }
+
         // If we're down to 1 instance, remove delete buttons and drag handles from remaining instance
         if (templateInfo.instanceCount === 1) {
             container.querySelectorAll<HTMLElement>("[data-scms-instance]").forEach((el) => {
@@ -645,6 +773,81 @@ export class TemplateManager {
 
         // Update toolbar
         this.updateToolbarTemplateContext();
+    }
+
+    /**
+     * Restore a previously deleted template instance (used by undo).
+     * Follows the same pattern as draft restoration: create instance, then apply content.
+     */
+    private restoreInstance(
+        templateId: string,
+        instanceId: string,
+        contentEntries: Map<string, string>,
+        orderContentKey: string,
+        previousOrderValue: string,
+    ): void {
+        // Restore the order array first
+        this.state.currentContent.set(orderContentKey, previousOrderValue);
+
+        // Parse the order to get the target instance list
+        let targetOrder: string[] = [];
+        try {
+            const parsed = JSON.parse(previousOrderValue);
+            if (parsed.type === "order" && Array.isArray(parsed.value)) {
+                targetOrder = parsed.value;
+            }
+        } catch {
+            this.log.error("Failed to parse order value for undo", { orderContentKey });
+            return;
+        }
+
+        // Create the instance DOM and register elements
+        const clone = this.addInstanceWithId(templateId, instanceId);
+        if (!clone) return;
+
+        // Reorder to match the original order
+        this.reorderInstances(templateId, targetOrder);
+
+        // Restore content entries and sync to DOM
+        for (const [key, value] of contentEntries) {
+            this.state.currentContent.set(key, value);
+            this.contentManager.syncAllElementsFromContent(key);
+            this.state.pendingDeletes.delete(key);
+        }
+
+        // Set up author mode (delete buttons, click handlers)
+        if (this.state.currentMode === "author") {
+            this.setupInstanceForAuthorMode(clone, templateId, instanceId);
+
+            // Re-add delete buttons and drag handles to all instances if we now have 2+
+            const templateInfo = this.state.templates.get(templateId);
+            if (templateInfo && templateInfo.instanceCount >= 2) {
+                const { container } = templateInfo;
+                let hasInlineControls = false;
+                container
+                    .querySelectorAll<HTMLElement>("[data-scms-instance]")
+                    .forEach((instanceElement) => {
+                        if (this.helpers.isInstanceAlsoEditable(instanceElement)) return;
+                        hasInlineControls = true;
+                        this.addInstanceDeleteButton(instanceElement);
+                        this.addInstanceDragHandle(instanceElement);
+                    });
+                if (hasInlineControls && !this.state.sortableInstances.has(templateId)) {
+                    this.initializeSortable(templateId, container);
+                }
+            }
+        }
+
+        // Update order content to match restored state
+        const templateInfo = this.state.templates.get(templateId);
+        if (templateInfo) {
+            this.updateOrderContent(templateId, templateInfo);
+        }
+
+        this.helpers.updateToolbarHasChanges();
+        this.updateToolbarTemplateContext();
+
+        this.log.debug("Restored template instance via undo", { templateId, instanceId });
     }
 
     /**

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -610,8 +610,9 @@ export class TemplateManager {
                     // No more DOM elements for this key
                     this.state.editableElements.delete(key);
                     this.state.editableTypes.delete(key);
-                    // Remove from currentContent (will be detected as pending delete)
+                    // Remove from currentContent and explicitly track deletion
                     this.state.currentContent.delete(key);
+                    this.state.pendingDeletes.add(key);
                 }
             }
         });

--- a/src/lazy/undo-manager.ts
+++ b/src/lazy/undo-manager.ts
@@ -1,0 +1,75 @@
+/**
+ * UndoManager - Generic undo/redo stack manager
+ *
+ * Implements the command pattern with dual stacks. Knows nothing about
+ * templates, content, or DOM — just holds UndoableAction objects.
+ *
+ * - push() adds to undo stack, clears redo stack
+ * - undo() pops from undo → calls action.undo() → pushes to redo
+ * - redo() pops from redo → calls action.redo() → pushes to undo
+ */
+
+import type { Logger } from "loganite";
+
+export interface UndoableAction {
+    type: string;
+    description: string;
+    timestamp: number;
+    undo(): void;
+    redo(): void;
+}
+
+export class UndoManager {
+    private undoStack: UndoableAction[] = [];
+    private redoStack: UndoableAction[] = [];
+
+    constructor(
+        private log: Logger,
+        private onStateChange: () => void,
+    ) {}
+
+    get canUndo(): boolean {
+        return this.undoStack.length > 0;
+    }
+
+    get canRedo(): boolean {
+        return this.redoStack.length > 0;
+    }
+
+    push(action: UndoableAction): void {
+        this.undoStack.push(action);
+        this.redoStack.length = 0;
+        this.log.debug("Action pushed to undo stack", {
+            type: action.type,
+            description: action.description,
+            undoDepth: this.undoStack.length,
+        });
+        this.onStateChange();
+    }
+
+    undo(): void {
+        const action = this.undoStack.pop();
+        if (!action) return;
+
+        this.log.debug("Undoing action", { type: action.type, description: action.description });
+        action.undo();
+        this.redoStack.push(action);
+        this.onStateChange();
+    }
+
+    redo(): void {
+        const action = this.redoStack.pop();
+        if (!action) return;
+
+        this.log.debug("Redoing action", { type: action.type, description: action.description });
+        action.redo();
+        this.undoStack.push(action);
+        this.onStateChange();
+    }
+
+    clear(): void {
+        this.undoStack.length = 0;
+        this.redoStack.length = 0;
+        this.onStateChange();
+    }
+}

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -169,6 +169,7 @@
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
+            el.innerHTML = "";
         });
 
         // Replace all text nodes with empty strings

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,7 +130,7 @@ export interface BatchUpdateResponse {
     groups: Record<string, { elements: Record<string, ContentElement> }>;
     deleted: {
         elements: string[];
-        groups: Record<string, string[]>;
+        groups: Record<string, { elements: string[] }>;
     };
 }
 

--- a/tests/browser/desktop/save/attribute-modal-save.test.ts
+++ b/tests/browser/desktop/save/attribute-modal-save.test.ts
@@ -70,12 +70,16 @@ async function resetState(): Promise<void> {
     const link = getLinkElement();
     if (link?.classList.contains("streamlined-editing")) {
         await clickToolbarButton("Cancel");
-        await waitForCondition(() => !link.classList.contains("streamlined-editing")).catch(() => {});
+        await waitForCondition(() => !link.classList.contains("streamlined-editing")).catch(
+            () => {},
+        );
     }
     const html = getHtmlElement();
     if (html?.classList.contains("streamlined-editing")) {
         await clickToolbarButton("Cancel");
-        await waitForCondition(() => !html.classList.contains("streamlined-editing")).catch(() => {});
+        await waitForCondition(() => !html.classList.contains("streamlined-editing")).catch(
+            () => {},
+        );
     }
 }
 
@@ -195,7 +199,9 @@ test("Attributes modal: attribute-only changes update currentContent and persist
     addBtn.click();
 
     // Wait for attribute to be added before applying
-    await waitForCondition(() => shadowRoot.querySelectorAll(".attribute-row, .attr-item").length > 0);
+    await waitForCondition(
+        () => shadowRoot.querySelectorAll(".attribute-row, .attr-item").length > 0,
+    );
 
     // Click Apply
     clickApplyButton(modal);

--- a/tests/browser/desktop/save/attribute-modal-save.test.ts
+++ b/tests/browser/desktop/save/attribute-modal-save.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Attribute-only modal save detection tests
+ *
+ * Verifies that applying changes via SEO, Accessibility, or Attributes modals
+ * (without any content edits) correctly updates currentContent, triggers the
+ * Save button (hasChanges), and persists to draft localStorage.
+ *
+ * Regression test for: https://github.com/streamlinedcms/client-sdk/issues/72
+ */
+
+import { test, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    waitForSelector,
+    clickToolbarButton,
+    setupTestHelpers,
+    getController,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+import type { SeoModal } from "~/src/components/seo-modal.js";
+import type { AccessibilityModal } from "~/src/components/accessibility-modal.js";
+import type { AttributesModal } from "~/src/components/attributes-modal.js";
+
+function getDraftKey(): string {
+    return getController()!.draftStorageKey;
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+    localStorage.removeItem(getDraftKey());
+});
+
+function getLinkElement(): HTMLAnchorElement {
+    return document.querySelector('[data-scms-link="attr-save-link"]') as HTMLAnchorElement;
+}
+
+function getHtmlElement(): HTMLElement {
+    return document.querySelector('[data-scms-html="attr-save-html"]') as HTMLElement;
+}
+
+function getToolbar(): Toolbar | null {
+    return document.querySelector("scms-toolbar") as Toolbar | null;
+}
+
+function clickApplyButton(modal: HTMLElement): void {
+    const shadowRoot = modal.shadowRoot!;
+    const buttons = shadowRoot.querySelectorAll("button");
+    for (const btn of buttons) {
+        if (btn.textContent?.trim() === "Apply") {
+            btn.click();
+            return;
+        }
+    }
+    throw new Error("Apply button not found in modal");
+}
+
+/**
+ * Helper to close any open modal and deselect
+ */
+async function resetState(): Promise<void> {
+    for (const tag of ["scms-seo-modal", "scms-accessibility-modal", "scms-attributes-modal"]) {
+        const modal = document.querySelector(tag);
+        if (modal) {
+            modal.dispatchEvent(new CustomEvent("cancel", { bubbles: true, composed: true }));
+            await waitForCondition(() => document.querySelector(tag) === null);
+        }
+    }
+    const link = getLinkElement();
+    if (link?.classList.contains("streamlined-editing")) {
+        await clickToolbarButton("Cancel");
+        await waitForCondition(() => !link.classList.contains("streamlined-editing")).catch(() => {});
+    }
+    const html = getHtmlElement();
+    if (html?.classList.contains("streamlined-editing")) {
+        await clickToolbarButton("Cancel");
+        await waitForCondition(() => !html.classList.contains("streamlined-editing")).catch(() => {});
+    }
+    await new Promise((r) => setTimeout(r, 50));
+}
+
+beforeEach(async () => {
+    await resetState();
+});
+
+afterEach(async () => {
+    await resetState();
+});
+
+// This is the first test — starts from a clean state
+test("SEO modal: attribute-only changes trigger hasChanges and persist to draft", async () => {
+    const link = getLinkElement();
+    const toolbar = getToolbar();
+
+    // Verify clean starting state
+    expect(toolbar!.hasChanges).toBe(false);
+
+    // Select and open SEO modal
+    link.click();
+    await waitForCondition(() => link.classList.contains("streamlined-editing"));
+    const clicked = await clickToolbarButton("SEO");
+    expect(clicked).toBe(true);
+    await waitForSelector("scms-seo-modal");
+
+    const modal = document.querySelector("scms-seo-modal") as SeoModal;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Change the rel attribute (attribute-only change, no content edit)
+    const relSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
+    relSelect.value = "nofollow";
+    relSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    // Click Apply
+    clickApplyButton(modal);
+    await waitForCondition(() => document.querySelector("scms-seo-modal") === null);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Core assertion for issue #72: hasChanges must be true
+    expect(toolbar!.hasChanges).toBe(true);
+
+    // Draft must include the SEO attribute change
+    const stored = localStorage.getItem(getDraftKey());
+    expect(stored).not.toBeNull();
+    const draft = JSON.parse(stored!);
+    const linkContent = draft.content["attr-save-link"];
+    expect(linkContent).toBeDefined();
+    expect(linkContent).toContain("nofollow");
+});
+
+test("Accessibility modal: attribute-only changes update currentContent and persist to draft", async () => {
+    const link = getLinkElement();
+
+    // Select and open Accessibility modal on the link element
+    link.click();
+    await waitForCondition(() => link.classList.contains("streamlined-editing"));
+    const clicked = await clickToolbarButton("Accessibility");
+    expect(clicked).toBe(true);
+    await waitForSelector("scms-accessibility-modal");
+
+    const modal = document.querySelector("scms-accessibility-modal") as AccessibilityModal;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Set aria-label (text input)
+    const inputs = shadowRoot.querySelectorAll('input[type="text"]');
+    const ariaLabelInput = inputs[0] as HTMLInputElement;
+    ariaLabelInput.value = "Navigate to example";
+    ariaLabelInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Click Apply
+    clickApplyButton(modal);
+    await waitForCondition(() => document.querySelector("scms-accessibility-modal") === null);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Draft must include the accessibility attribute change for the link
+    const stored = localStorage.getItem(getDraftKey());
+    expect(stored).not.toBeNull();
+    const draft = JSON.parse(stored!);
+    const linkContent = draft.content["attr-save-link"];
+    expect(linkContent).toBeDefined();
+    expect(linkContent).toContain("aria-label");
+});
+
+test("Attributes modal: attribute-only changes update currentContent and persist to draft", async () => {
+    const link = getLinkElement();
+
+    // Select and open Attributes modal
+    link.click();
+    await waitForCondition(() => link.classList.contains("streamlined-editing"));
+    const clicked = await clickToolbarButton("Attributes");
+    expect(clicked).toBe(true);
+    await waitForSelector("scms-attributes-modal");
+
+    const modal = document.querySelector("scms-attributes-modal") as AttributesModal;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Add a custom attribute
+    const inputs = shadowRoot.querySelectorAll(".add-form input");
+    const nameInput = inputs[0] as HTMLInputElement;
+    const valueInput = inputs[1] as HTMLInputElement;
+
+    nameInput.value = "data-tracking";
+    nameInput.dispatchEvent(new Event("input", { bubbles: true }));
+    valueInput.value = "cta-link";
+    valueInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const addBtn = shadowRoot.querySelector(".add-form button") as HTMLButtonElement;
+    addBtn.click();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Click Apply
+    clickApplyButton(modal);
+    await waitForCondition(() => document.querySelector("scms-attributes-modal") === null);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Draft must include the custom attribute for the link element
+    const stored = localStorage.getItem(getDraftKey());
+    expect(stored).not.toBeNull();
+    const draft = JSON.parse(stored!);
+    const linkContent = draft.content["attr-save-link"];
+    expect(linkContent).toBeDefined();
+    expect(linkContent).toContain("data-tracking");
+});

--- a/tests/browser/desktop/save/attribute-modal-save.test.ts
+++ b/tests/browser/desktop/save/attribute-modal-save.test.ts
@@ -8,7 +8,7 @@
  * Regression test for: https://github.com/streamlinedcms/client-sdk/issues/72
  */
 
-import { test, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import { test, expect, beforeAll, beforeEach } from "vitest";
 import {
     initializeSDK,
     waitForCondition,
@@ -77,14 +77,9 @@ async function resetState(): Promise<void> {
         await clickToolbarButton("Cancel");
         await waitForCondition(() => !html.classList.contains("streamlined-editing")).catch(() => {});
     }
-    await new Promise((r) => setTimeout(r, 50));
 }
 
 beforeEach(async () => {
-    await resetState();
-});
-
-afterEach(async () => {
     await resetState();
 });
 
@@ -105,7 +100,9 @@ test("SEO modal: attribute-only changes trigger hasChanges and persist to draft"
 
     const modal = document.querySelector("scms-seo-modal") as SeoModal;
     const shadowRoot = modal.shadowRoot!;
-    await new Promise((r) => setTimeout(r, 100));
+
+    // Wait for modal to render its select element
+    await waitForCondition(() => shadowRoot.querySelector("select") !== null);
 
     // Change the rel attribute (attribute-only change, no content edit)
     const relSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
@@ -115,12 +112,12 @@ test("SEO modal: attribute-only changes trigger hasChanges and persist to draft"
     // Click Apply
     clickApplyButton(modal);
     await waitForCondition(() => document.querySelector("scms-seo-modal") === null);
-    await new Promise((r) => setTimeout(r, 100));
 
     // Core assertion for issue #72: hasChanges must be true
-    expect(toolbar!.hasChanges).toBe(true);
+    await waitForCondition(() => toolbar!.hasChanges === true);
 
     // Draft must include the SEO attribute change
+    await waitForCondition(() => localStorage.getItem(getDraftKey()) !== null);
     const stored = localStorage.getItem(getDraftKey());
     expect(stored).not.toBeNull();
     const draft = JSON.parse(stored!);
@@ -141,7 +138,9 @@ test("Accessibility modal: attribute-only changes update currentContent and pers
 
     const modal = document.querySelector("scms-accessibility-modal") as AccessibilityModal;
     const shadowRoot = modal.shadowRoot!;
-    await new Promise((r) => setTimeout(r, 100));
+
+    // Wait for modal to render its inputs
+    await waitForCondition(() => shadowRoot.querySelectorAll('input[type="text"]').length > 0);
 
     // Set aria-label (text input)
     const inputs = shadowRoot.querySelectorAll('input[type="text"]');
@@ -152,9 +151,12 @@ test("Accessibility modal: attribute-only changes update currentContent and pers
     // Click Apply
     clickApplyButton(modal);
     await waitForCondition(() => document.querySelector("scms-accessibility-modal") === null);
-    await new Promise((r) => setTimeout(r, 100));
 
     // Draft must include the accessibility attribute change for the link
+    await waitForCondition(() => {
+        const s = localStorage.getItem(getDraftKey());
+        return s !== null && s.includes("aria-label");
+    });
     const stored = localStorage.getItem(getDraftKey());
     expect(stored).not.toBeNull();
     const draft = JSON.parse(stored!);
@@ -175,7 +177,9 @@ test("Attributes modal: attribute-only changes update currentContent and persist
 
     const modal = document.querySelector("scms-attributes-modal") as AttributesModal;
     const shadowRoot = modal.shadowRoot!;
-    await new Promise((r) => setTimeout(r, 100));
+
+    // Wait for modal to render its form inputs
+    await waitForCondition(() => shadowRoot.querySelectorAll(".add-form input").length >= 2);
 
     // Add a custom attribute
     const inputs = shadowRoot.querySelectorAll(".add-form input");
@@ -189,14 +193,19 @@ test("Attributes modal: attribute-only changes update currentContent and persist
 
     const addBtn = shadowRoot.querySelector(".add-form button") as HTMLButtonElement;
     addBtn.click();
-    await new Promise((r) => setTimeout(r, 100));
+
+    // Wait for attribute to be added before applying
+    await waitForCondition(() => shadowRoot.querySelectorAll(".attribute-row, .attr-item").length > 0);
 
     // Click Apply
     clickApplyButton(modal);
     await waitForCondition(() => document.querySelector("scms-attributes-modal") === null);
-    await new Promise((r) => setTimeout(r, 100));
 
     // Draft must include the custom attribute for the link element
+    await waitForCondition(() => {
+        const s = localStorage.getItem(getDraftKey());
+        return s !== null && s.includes("data-tracking");
+    });
     const stored = localStorage.getItem(getDraftKey());
     expect(stored).not.toBeNull();
     const draft = JSON.parse(stored!);

--- a/tests/browser/desktop/save/grouped-elements.test.ts
+++ b/tests/browser/desktop/save/grouped-elements.test.ts
@@ -203,9 +203,7 @@ test("saving after deleting a grouped template instance succeeds", async () => {
     const deleteButton = lastInstance.querySelector(".scms-instance-delete") as HTMLElement;
     deleteButton.click();
 
-    await waitForCondition(
-        () => container?.querySelectorAll("[data-scms-instance]").length === 1,
-    );
+    await waitForCondition(() => container?.querySelectorAll("[data-scms-instance]").length === 1);
 
     expect(toolbar!.hasChanges).toBe(true);
 

--- a/tests/browser/desktop/save/grouped-elements.test.ts
+++ b/tests/browser/desktop/save/grouped-elements.test.ts
@@ -32,6 +32,34 @@ beforeAll(async () => {
         JSON.stringify({ type: "text", value: "Acme Corp" }),
     );
 
+    // Seed testimonials template instances inside the sidebar group
+    // (used by the grouped deletion test)
+    await setContent(
+        appId,
+        "sidebar:testimonials.test1.quote",
+        JSON.stringify({ type: "text", value: "Great product!" }),
+    );
+    await setContent(
+        appId,
+        "sidebar:testimonials.test1.author",
+        JSON.stringify({ type: "text", value: "John Doe" }),
+    );
+    await setContent(
+        appId,
+        "sidebar:testimonials.test2.quote",
+        JSON.stringify({ type: "text", value: "Love it!" }),
+    );
+    await setContent(
+        appId,
+        "sidebar:testimonials.test2.author",
+        JSON.stringify({ type: "text", value: "Jane Smith" }),
+    );
+    await setContent(
+        appId,
+        "sidebar:testimonials._order",
+        JSON.stringify({ type: "order", value: ["test1", "test2"] }),
+    );
+
     await initializeSDK({ appId });
 });
 
@@ -153,6 +181,35 @@ test("multiple grouped elements can be edited and saved together", async () => {
     expect(toolbar!.hasChanges).toBe(true);
 
     // Save both
+    await clickToolbarButton("Save");
+
+    await waitForCondition(() => !toolbar!.hasChanges, 5000);
+
+    expect(toolbar!.hasChanges).toBe(false);
+});
+
+test("saving after deleting a grouped template instance succeeds", async () => {
+    // The sidebar group contains a testimonials template with 2 instances.
+    // Deleting an instance produces grouped element deletions in the API response
+    // (deleted.groups = { sidebar: { elements: ["testimonials.test2.quote", ...] } }).
+    const container = document.querySelector('[data-scms-template="testimonials"]');
+    const instances = container?.querySelectorAll("[data-scms-instance]");
+    const toolbar = getToolbar();
+
+    expect(instances?.length).toBe(2);
+
+    // Click delete on the last instance
+    const lastInstance = instances![instances!.length - 1];
+    const deleteButton = lastInstance.querySelector(".scms-instance-delete") as HTMLElement;
+    deleteButton.click();
+
+    await waitForCondition(
+        () => container?.querySelectorAll("[data-scms-instance]").length === 1,
+    );
+
+    expect(toolbar!.hasChanges).toBe(true);
+
+    // Save — this exercises the deleted.groups response path
     await clickToolbarButton("Save");
 
     await waitForCondition(() => !toolbar!.hasChanges, 5000);

--- a/tests/browser/desktop/save/pending-deletes.test.ts
+++ b/tests/browser/desktop/save/pending-deletes.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Pending deletes tests
+ *
+ * Regression tests for https://github.com/streamlinedcms/client-sdk/issues/76
+ *
+ * Verifies that only user-driven deletions (template instance removal) are
+ * tracked as pending deletes. Elements that exist in savedContentKeys but
+ * not in the current page DOM (e.g. elements on other pages) must NOT be
+ * treated as pending deletes.
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    clickToolbarButton,
+    setupTestHelpers,
+    generateTestAppId,
+    getController,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+const TEMPLATE_ID = "team-deletes";
+
+let appId: string;
+
+function getDraftKey(): string {
+    return getController()!.draftStorageKey;
+}
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getTeamContainer(): HTMLElement {
+    return document.querySelector(`[data-scms-template="${TEMPLATE_ID}"]`) as HTMLElement;
+}
+
+async function editElement(element: HTMLElement, content: string): Promise<void> {
+    element.click();
+    await waitForCondition(() => element.classList.contains("streamlined-editing"));
+    element.textContent = content;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+}
+
+declare const __SDK_API_URL__: string;
+
+async function fetchServerContent(): Promise<Record<string, unknown>> {
+    const response = await fetch(`${__SDK_API_URL__}/apps/${appId}/content`);
+    return response.json();
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    appId = generateTestAppId();
+
+    // Set up 2 instances on the current page
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member1.name`,
+        JSON.stringify({ type: "text", value: "Alice" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member1.role`,
+        JSON.stringify({ type: "text", value: "CEO" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member2.name`,
+        JSON.stringify({ type: "text", value: "Bob" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member2.role`,
+        JSON.stringify({ type: "text", value: "CTO" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}._order`,
+        JSON.stringify({ type: "order", value: ["member1", "member2"] }),
+    );
+
+    // Set up content that belongs to a DIFFERENT page (not in the DOM).
+    // These keys exist in the API response but have no corresponding DOM elements.
+    await setContent(appId, "other-page-title", JSON.stringify({ type: "html", value: "Other Page" }));
+    await setContent(appId, "other-page-bio", JSON.stringify({ type: "html", value: "Bio text" }));
+
+    await initializeSDK({ appId });
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+    localStorage.removeItem(getDraftKey());
+});
+
+test("elements not in the DOM are not marked as pending deletes in draft", async () => {
+    // Edit something to trigger a draft save
+    const nameEl = getTeamContainer().querySelector('[data-scms-text="name"]') as HTMLElement;
+    await editElement(nameEl, "Alice Modified");
+
+    // Check the draft in localStorage
+    const stored = localStorage.getItem(getDraftKey());
+    expect(stored).not.toBeNull();
+
+    const draft = JSON.parse(stored!);
+
+    // The deleted array must NOT contain the other-page elements
+    expect(draft.deleted).not.toContain("other-page-title");
+    expect(draft.deleted).not.toContain("other-page-bio");
+
+    // The deleted array should be empty (no user-driven deletions occurred)
+    expect(draft.deleted).toEqual([]);
+});
+
+test("saving does not delete elements from other pages", async () => {
+    const nameEl = getTeamContainer().querySelector('[data-scms-text="name"]') as HTMLElement;
+    const toolbar = getToolbar();
+
+    await editElement(nameEl, "Alice Saved");
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !toolbar.hasChanges, 5000);
+
+    // Fetch what the server has after save
+    const serverContent = await fetchServerContent();
+    const elements = serverContent.elements as Record<string, { content: string }>;
+
+    // Other-page elements must still exist on the server
+    expect(elements["other-page-title"]).toBeDefined();
+    expect(elements["other-page-bio"]).toBeDefined();
+});
+
+test("removing a template instance tracks deletes and save removes them from server", async () => {
+    const container = getTeamContainer();
+    const toolbar = getToolbar();
+
+    // Should have 2 instances
+    let instances = container.querySelectorAll("[data-scms-instance]");
+    expect(instances.length).toBe(2);
+
+    // Delete the last instance
+    const lastInstance = instances[instances.length - 1];
+    const deleteButton = lastInstance.querySelector(".scms-instance-delete") as HTMLElement;
+    deleteButton.click();
+
+    await waitForCondition(() => container.querySelectorAll("[data-scms-instance]").length === 1);
+
+    // A draft should have been saved with the deleted instance's element keys
+    const stored = localStorage.getItem(getDraftKey());
+    expect(stored).not.toBeNull();
+
+    const draft = JSON.parse(stored!);
+    expect(draft.deleted.length).toBeGreaterThan(0);
+
+    // The deleted keys should be for the removed instance's elements, not other-page content
+    for (const key of draft.deleted) {
+        expect(key).toMatch(new RegExp(`^${TEMPLATE_ID}\\.`));
+    }
+    expect(draft.deleted).not.toContain("other-page-title");
+    expect(draft.deleted).not.toContain("other-page-bio");
+
+    // Save to delete from server
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !toolbar.hasChanges, 5000);
+
+    // Verify server no longer has the deleted instance's elements
+    const serverContent = await fetchServerContent();
+    const elements = serverContent.elements as Record<string, { content: string }>;
+
+    for (const key of draft.deleted) {
+        expect(elements[key]).toBeUndefined();
+    }
+
+    // Other-page content must still be intact
+    expect(elements["other-page-title"]).toBeDefined();
+    expect(elements["other-page-bio"]).toBeDefined();
+});

--- a/tests/browser/desktop/save/pending-deletes.test.ts
+++ b/tests/browser/desktop/save/pending-deletes.test.ts
@@ -85,7 +85,11 @@ beforeAll(async () => {
 
     // Set up content that belongs to a DIFFERENT page (not in the DOM).
     // These keys exist in the API response but have no corresponding DOM elements.
-    await setContent(appId, "other-page-title", JSON.stringify({ type: "html", value: "Other Page" }));
+    await setContent(
+        appId,
+        "other-page-title",
+        JSON.stringify({ type: "html", value: "Other Page" }),
+    );
     await setContent(appId, "other-page-bio", JSON.stringify({ type: "html", value: "Bio text" }));
 
     await initializeSDK({ appId });

--- a/tests/browser/desktop/save/template-unsaved-fields.test.ts
+++ b/tests/browser/desktop/save/template-unsaved-fields.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Template unsaved fields save tests
+ *
+ * Regression test for https://github.com/streamlinedcms/client-sdk/issues/70
+ *
+ * When editing a single field on an existing template instance, all unsaved
+ * sibling fields across all instances should also be persisted — not just
+ * the one that was modified.
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    clickToolbarButton,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+const TEMPLATE_ID = "team-save-unsaved";
+
+let appId: string;
+
+beforeAll(async () => {
+    setupTestHelpers();
+    appId = generateTestAppId();
+
+    // Set up 2 instances: member1 has only "name" saved, member2 has nothing saved.
+    // This simulates a template where some fields/instances have been persisted
+    // but others still have their HTML-default values and have never been sent to the API.
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member1.name`,
+        JSON.stringify({ type: "text", value: "Alice" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}._order`,
+        JSON.stringify({ type: "order", value: ["member1", "member2"] }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getNameElement(): HTMLElement {
+    return document.querySelector(
+        `[data-scms-template="${TEMPLATE_ID}"] [data-scms-text="name"]`,
+    ) as HTMLElement;
+}
+
+function getRoleElement(): HTMLElement {
+    return document.querySelector(
+        `[data-scms-template="${TEMPLATE_ID}"] [data-scms-text="role"]`,
+    ) as HTMLElement;
+}
+
+async function editElement(element: HTMLElement, content: string): Promise<void> {
+    element.click();
+    await waitForCondition(() => element.classList.contains("streamlined-editing"));
+    element.textContent = content;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 100));
+}
+
+declare const __SDK_API_URL__: string;
+
+/**
+ * Fetch all saved content from the test server for this app
+ */
+async function fetchServerContent(): Promise<Record<string, unknown>> {
+    const response = await fetch(`${__SDK_API_URL__}/apps/${appId}/content`);
+    return response.json();
+}
+
+test("editing one template field also saves unsaved sibling fields and instances", async () => {
+    const nameEl = getNameElement();
+    const toolbar = getToolbar();
+
+    // Verify initial state: member1's name is "Alice" (from API).
+    // member1's role and all of member2's fields are empty because
+    // cloneTemplateInstances() strips content and they were never saved.
+    expect(nameEl.textContent).toBe("Alice");
+
+    // Verify both instances exist
+    const instances = document.querySelectorAll(
+        `[data-scms-template="${TEMPLATE_ID}"] [data-scms-instance]`,
+    );
+    expect(instances.length).toBe(2);
+
+    // Edit only member1's name field
+    await editElement(nameEl, "Alice Updated");
+    expect(toolbar.hasChanges).toBe(true);
+
+    // Save
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !toolbar.hasChanges, 5000);
+
+    // Fetch what was actually saved to the server
+    const serverContent = await fetchServerContent();
+    const elements = serverContent.elements as Record<string, { content: string }> | undefined;
+
+    // member1's unsaved role field should also be persisted
+    const member1RoleKey = `${TEMPLATE_ID}.member1.role`;
+    expect(elements?.[member1RoleKey]).toBeDefined();
+    expect(elements?.[member1RoleKey]?.content).toBeDefined();
+
+    // member2's fields should also be persisted (entirely unsaved sibling instance)
+    const member2NameKey = `${TEMPLATE_ID}.member2.name`;
+    const member2RoleKey = `${TEMPLATE_ID}.member2.role`;
+    expect(elements?.[member2NameKey]).toBeDefined();
+    expect(elements?.[member2NameKey]?.content).toBeDefined();
+    expect(elements?.[member2RoleKey]).toBeDefined();
+    expect(elements?.[member2RoleKey]?.content).toBeDefined();
+});

--- a/tests/browser/desktop/templates/inline-formatting-strip.test.ts
+++ b/tests/browser/desktop/templates/inline-formatting-strip.test.ts
@@ -39,22 +39,15 @@ beforeAll(async () => {
 });
 
 test("new template instance has no leftover inline formatting in editable elements", async () => {
-    const teamContainer = document.querySelector(
-        '[data-scms-template="team-inline-fmt"]',
-    );
-    const initialCount =
-        teamContainer?.querySelectorAll(".team-member").length ?? 0;
+    const teamContainer = document.querySelector('[data-scms-template="team-inline-fmt"]');
+    const initialCount = teamContainer?.querySelectorAll(".team-member").length ?? 0;
 
     // Click add button to create a new instance
-    const addButton = teamContainer?.querySelector(
-        ".scms-template-add",
-    ) as HTMLElement;
+    const addButton = teamContainer?.querySelector(".scms-template-add") as HTMLElement;
     addButton.click();
 
     await waitForCondition(
-        () =>
-            teamContainer?.querySelectorAll(".team-member").length ===
-            initialCount + 1,
+        () => teamContainer?.querySelectorAll(".team-member").length === initialCount + 1,
     );
 
     const teamMembers = teamContainer?.querySelectorAll(".team-member");
@@ -70,9 +63,7 @@ test("new template instance has no leftover inline formatting in editable elemen
 });
 
 test("new template instance preserves inline formatting in non-editable elements", async () => {
-    const teamContainer = document.querySelector(
-        '[data-scms-template="team-inline-fmt"]',
-    );
+    const teamContainer = document.querySelector('[data-scms-template="team-inline-fmt"]');
 
     // Get the last instance (added by previous test)
     const teamMembers = teamContainer?.querySelectorAll(".team-member");

--- a/tests/browser/desktop/templates/inline-formatting-strip.test.ts
+++ b/tests/browser/desktop/templates/inline-formatting-strip.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests that stripTemplateContent removes inline formatting elements
+ * (e.g. <strong>, <em>) from editable elements inside templates.
+ *
+ * Regression test for https://github.com/streamlinedcms/client-sdk/issues/73
+ */
+
+import { test, expect, beforeAll } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    const appId = generateTestAppId();
+
+    // Start with 1 instance whose editable has rich HTML content
+    await setContent(
+        appId,
+        "team-inline-fmt.inst1.name",
+        JSON.stringify({ type: "html", value: "Alice <strong>Smith</strong>" }),
+    );
+    await setContent(
+        appId,
+        "team-inline-fmt.inst1.role",
+        JSON.stringify({ type: "text", value: "CEO" }),
+    );
+    await setContent(
+        appId,
+        "team-inline-fmt._order",
+        JSON.stringify({ type: "order", value: ["inst1"] }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+test("new template instance has no leftover inline formatting in editable elements", async () => {
+    const teamContainer = document.querySelector(
+        '[data-scms-template="team-inline-fmt"]',
+    );
+    const initialCount =
+        teamContainer?.querySelectorAll(".team-member").length ?? 0;
+
+    // Click add button to create a new instance
+    const addButton = teamContainer?.querySelector(
+        ".scms-template-add",
+    ) as HTMLElement;
+    addButton.click();
+
+    await waitForCondition(
+        () =>
+            teamContainer?.querySelectorAll(".team-member").length ===
+            initialCount + 1,
+    );
+
+    const teamMembers = teamContainer?.querySelectorAll(".team-member");
+    const newInstance = teamMembers?.[teamMembers.length - 1];
+
+    // The html editable should be completely empty — no leftover <strong>, <em>, etc.
+    const newName = newInstance?.querySelector('[data-scms-html="name"]');
+    expect(newName?.innerHTML).toBe("");
+
+    // The text editable should also be empty
+    const newRole = newInstance?.querySelector('[data-scms-text="role"]');
+    expect(newRole?.textContent).toBe("");
+});
+
+test("new template instance preserves inline formatting in non-editable elements", async () => {
+    const teamContainer = document.querySelector(
+        '[data-scms-template="team-inline-fmt"]',
+    );
+
+    // Get the last instance (added by previous test)
+    const teamMembers = teamContainer?.querySelectorAll(".team-member");
+    const newInstance = teamMembers?.[teamMembers.length - 1];
+
+    // The non-editable badge should preserve its <strong> tag (text cleared, structure kept)
+    const badge = newInstance?.querySelector(".badge");
+    expect(badge?.querySelector("strong")).not.toBeNull();
+});

--- a/tests/browser/desktop/templates/undo.test.ts
+++ b/tests/browser/desktop/templates/undo.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Undo/redo tests for template instance deletion
+ *
+ * Tests for https://github.com/streamlinedcms/client-sdk/issues/31
+ *
+ * Verifies that deleting a template instance can be undone, restoring
+ * the instance with its content, order position, and author mode controls.
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+const TEMPLATE_ID = "team-undo";
+
+let appId: string;
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getContainer(): HTMLElement {
+    return document.querySelector(`[data-scms-template="${TEMPLATE_ID}"]`) as HTMLElement;
+}
+
+function getInstances(): NodeListOf<HTMLElement> {
+    return getContainer().querySelectorAll("[data-scms-instance]");
+}
+
+function clickUndoButton(): boolean {
+    const toolbar = getToolbar();
+    const buttons = toolbar.shadowRoot?.querySelectorAll("button") || [];
+    for (const btn of buttons) {
+        if (btn.getAttribute("aria-label") === "Undo") {
+            btn.click();
+            return true;
+        }
+    }
+    return false;
+}
+
+async function deleteLastInstance(): Promise<void> {
+    const instances = getInstances();
+    const lastInstance = instances[instances.length - 1];
+    const deleteButton = lastInstance.querySelector(".scms-instance-delete") as HTMLElement;
+    const countBefore = instances.length;
+    deleteButton.click();
+    await waitForCondition(() => getInstances().length === countBefore - 1);
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    appId = generateTestAppId();
+
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member1.name`,
+        JSON.stringify({ type: "text", value: "Alice" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member1.role`,
+        JSON.stringify({ type: "text", value: "CEO" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member2.name`,
+        JSON.stringify({ type: "text", value: "Bob" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member2.role`,
+        JSON.stringify({ type: "text", value: "CTO" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member3.name`,
+        JSON.stringify({ type: "text", value: "Carol" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}.member3.role`,
+        JSON.stringify({ type: "text", value: "CFO" }),
+    );
+    await setContent(
+        appId,
+        `${TEMPLATE_ID}._order`,
+        JSON.stringify({ type: "order", value: ["member1", "member2", "member3"] }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+test("undo restores a deleted template instance with its content", async () => {
+    // Start with 3 instances
+    expect(getInstances().length).toBe(3);
+
+    // Verify Bob's content before deletion
+    const instances = getInstances();
+    const bobInstance = instances[1];
+    const bobName = bobInstance.querySelector('[data-scms-text="name"]') as HTMLElement;
+    expect(bobName.textContent).toBe("Bob");
+
+    // Get Bob's instance ID
+    const bobInstanceId = bobInstance.getAttribute("data-scms-instance");
+
+    // Delete the last instance (Carol)
+    await deleteLastInstance();
+    expect(getInstances().length).toBe(2);
+
+    // Undo
+    const clicked = clickUndoButton();
+    expect(clicked).toBe(true);
+    await waitForCondition(() => getInstances().length === 3);
+
+    // Carol should be restored with content
+    const restoredInstances = getInstances();
+    expect(restoredInstances.length).toBe(3);
+
+    // Find the restored instance (should be back in position 3)
+    const restoredInstance = restoredInstances[2];
+    const restoredName = restoredInstance.querySelector('[data-scms-text="name"]') as HTMLElement;
+    const restoredRole = restoredInstance.querySelector('[data-scms-text="role"]') as HTMLElement;
+    expect(restoredName.textContent).toBe("Carol");
+    expect(restoredRole.textContent).toBe("CFO");
+
+    // Bob should still be in position 2 (order preserved)
+    const bobAfterUndo = restoredInstances[1];
+    expect(bobAfterUndo.getAttribute("data-scms-instance")).toBe(bobInstanceId);
+});
+
+test("redo re-deletes after undo", async () => {
+    // Should have 3 instances from previous test's undo
+    expect(getInstances().length).toBe(3);
+
+    // Delete last instance (Carol again)
+    await deleteLastInstance();
+    expect(getInstances().length).toBe(2);
+
+    // Undo — Carol restored
+    clickUndoButton();
+    await waitForCondition(() => getInstances().length === 3);
+
+    // Redo — Carol deleted again
+    const toolbar = getToolbar();
+    expect(toolbar.canRedo).toBe(true);
+
+    // Find and click redo button (if rendered) — for now redo isn't in the toolbar UI,
+    // but canRedo should be true. We can verify by deleting again and checking state.
+    // Since redo button isn't in UI yet, we verify the toolbar state
+    expect(toolbar.canUndo).toBe(false);
+    expect(toolbar.canRedo).toBe(true);
+});
+
+test("new action clears the redo stack", async () => {
+    const toolbar = getToolbar();
+
+    // Should have 3 instances
+    expect(getInstances().length).toBe(3);
+
+    // Delete Carol
+    await deleteLastInstance();
+    expect(getInstances().length).toBe(2);
+
+    // Undo — Carol back, redo available
+    clickUndoButton();
+    await waitForCondition(() => getInstances().length === 3);
+    expect(toolbar.canRedo).toBe(true);
+
+    // Perform a new delete (Bob) — should clear redo stack
+    await deleteLastInstance();
+    expect(getInstances().length).toBe(2);
+
+    // Redo should no longer be available (new action cleared it)
+    expect(toolbar.canRedo).toBe(false);
+
+    // But undo should be available (for the new deletion)
+    expect(toolbar.canUndo).toBe(true);
+
+    // Undo to restore for next test
+    clickUndoButton();
+    await waitForCondition(() => getInstances().length === 3);
+});
+
+test("undo restores author mode controls on the instance", async () => {
+    // Should have 3 instances
+    expect(getInstances().length).toBe(3);
+
+    // Delete last instance
+    await deleteLastInstance();
+    expect(getInstances().length).toBe(2);
+
+    // Undo
+    clickUndoButton();
+    await waitForCondition(() => getInstances().length === 3);
+
+    // The restored instance should have a delete button
+    const restoredInstance = getInstances()[2];
+    const deleteBtn = restoredInstance.querySelector(".scms-instance-delete");
+    expect(deleteBtn).not.toBeNull();
+
+    // Editable elements should have the streamlined-editable class
+    const editableElements = restoredInstance.querySelectorAll(".streamlined-editable");
+    expect(editableElements.length).toBeGreaterThan(0);
+});

--- a/tests/browser/desktop/toolbar/buttons.test.ts
+++ b/tests/browser/desktop/toolbar/buttons.test.ts
@@ -145,46 +145,6 @@ test("clicking outside element deselects it", async () => {
     expect(htmlElement.classList.contains("streamlined-editing")).toBe(false);
 });
 
-// --- Element badge tests ---
-
-test("element badge shows correct element ID for html element", async () => {
-    const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
-    htmlElement.click();
-
-    await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
-
-    const shadowRoot = getToolbarShadow();
-    const badge = shadowRoot?.querySelector("scms-element-badge");
-    expect(badge).not.toBeNull();
-    expect(badge?.getAttribute("element-id")).toBe("test-title");
-    expect(badge?.getAttribute("element-type")).toBe("html");
-});
-
-test("element badge shows correct type for link element", async () => {
-    const linkElement = document.querySelector('[data-scms-link="test-link"]') as HTMLElement;
-    linkElement.click();
-
-    await waitForCondition(() => linkElement.classList.contains("streamlined-editing"));
-
-    const shadowRoot = getToolbarShadow();
-    const badge = shadowRoot?.querySelector("scms-element-badge");
-    expect(badge?.getAttribute("element-id")).toBe("test-link");
-    expect(badge?.getAttribute("element-type")).toBe("link");
-});
-
-test("element badge shows correct type for text element", async () => {
-    const textElement = document.querySelector('[data-scms-text="name"]') as HTMLElement;
-    if (!textElement) return;
-
-    textElement.click();
-
-    await waitForCondition(() => textElement.classList.contains("streamlined-editing"));
-
-    const shadowRoot = getToolbarShadow();
-    const badge = shadowRoot?.querySelector("scms-element-badge");
-    expect(badge?.getAttribute("element-type")).toBe("text");
-});
-
 // --- Mode toggle tests ---
 
 test("mode toggle is visible in toolbar", async () => {

--- a/tests/browser/desktop/toolbar/element-selection.test.ts
+++ b/tests/browser/desktop/toolbar/element-selection.test.ts
@@ -74,18 +74,6 @@ test("selecting different elements updates toolbar", async () => {
     expect(toolbar?.activeElementType).toBe("link");
 });
 
-test("toolbar element badge shows element ID", async () => {
-    const toolbar = getToolbar();
-    const element = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
-
-    element.click();
-    await waitForCondition(() => element.classList.contains("streamlined-editing"));
-
-    const shadowRoot = toolbar!.shadowRoot!;
-    const badge = shadowRoot.querySelector("scms-element-badge");
-    expect(badge).not.toBeNull();
-});
-
 test("mode is set to author when SDK initializes with mock auth", async () => {
     const toolbar = getToolbar();
     expect(toolbar?.mode).toBe("author");

--- a/tests/browser/mobile/toolbar/mobile.test.ts
+++ b/tests/browser/mobile/toolbar/mobile.test.ts
@@ -71,4 +71,3 @@ test("clicking menu button toggles expanded state", async () => {
     // Should be collapsed
     expect(menuBtn.getAttribute("aria-label")).toContain("Open");
 });
-

--- a/tests/browser/mobile/toolbar/mobile.test.ts
+++ b/tests/browser/mobile/toolbar/mobile.test.ts
@@ -72,25 +72,3 @@ test("clicking menu button toggles expanded state", async () => {
     expect(menuBtn.getAttribute("aria-label")).toContain("Open");
 });
 
-test("mobile view shows element badge when element is selected", async () => {
-    // Click on an element to select it (mobile requires two taps for text/html)
-    const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
-
-    // First click selects
-    htmlElement.click();
-    await waitForCondition(() => htmlElement.classList.contains("streamlined-selected"));
-
-    // Wait to avoid double-tap detection (400ms threshold)
-    await new Promise((r) => setTimeout(r, 450));
-
-    // Second click edits
-    htmlElement.click();
-    await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
-
-    const toolbar = getToolbar();
-    const shadowRoot = toolbar.shadowRoot!;
-
-    // Element badge should be visible when element is selected
-    const badge = shadowRoot.querySelector("scms-element-badge");
-    expect(badge).not.toBeNull();
-});

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -206,5 +206,11 @@
                 <li data-scms-text="item">Third item</li>
             </ol>
         </div>
+
+        <!-- Elements for attribute-only modal save detection tests (isolated) -->
+        <div class="test-section">
+            <a href="https://example.com" data-scms-link="attr-save-link">Attr Save Link</a>
+            <h1 data-scms-html="attr-save-html">Attr Save HTML</h1>
+        </div>
     </body>
 </html>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -207,6 +207,18 @@
             </ol>
         </div>
 
+        <!-- Template for inline formatting stripping tests (isolated) -->
+        <div class="test-section">
+            <h2>Team Inline Formatting Test</h2>
+            <div data-scms-template="team-inline-fmt" class="team-container">
+                <div class="team-member">
+                    <h3 data-scms-html="name">This is <strong>bold</strong> and <em>italic</em> name</h3>
+                    <p data-scms-text="role">Default Role</p>
+                    <span class="badge">Team <strong>Lead</strong></span>
+                </div>
+            </div>
+        </div>
+
         <!-- Elements for attribute-only modal save detection tests (isolated) -->
         <div class="test-section">
             <a href="https://example.com" data-scms-link="attr-save-link">Attr Save Link</a>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -186,6 +186,17 @@
             </div>
         </div>
 
+        <!-- Template for save/template-unsaved-fields tests (isolated) -->
+        <div class="test-section">
+            <h2>Team Save Unsaved Test</h2>
+            <div data-scms-template="team-save-unsaved" class="team-container">
+                <div class="team-member">
+                    <h3 data-scms-text="name">Default Name</h3>
+                    <p data-scms-text="role">Default Role</p>
+                </div>
+            </div>
+        </div>
+
         <!-- Template where instance element IS the editable element -->
         <div class="test-section">
             <h2>Checklist (Instance = Editable)</h2>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -212,7 +212,9 @@
             <h2>Team Inline Formatting Test</h2>
             <div data-scms-template="team-inline-fmt" class="team-container">
                 <div class="team-member">
-                    <h3 data-scms-html="name">This is <strong>bold</strong> and <em>italic</em> name</h3>
+                    <h3 data-scms-html="name">
+                        This is <strong>bold</strong> and <em>italic</em> name
+                    </h3>
                     <p data-scms-text="role">Default Role</p>
                     <span class="badge">Team <strong>Lead</strong></span>
                 </div>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -219,6 +219,17 @@
             </div>
         </div>
 
+        <!-- Template for pending-deletes tests (isolated) -->
+        <div class="test-section">
+            <h2>Team Pending Deletes Test</h2>
+            <div data-scms-template="team-deletes" class="team-container">
+                <div class="team-member">
+                    <h3 data-scms-text="name">Default Name</h3>
+                    <p data-scms-text="role">Default Role</p>
+                </div>
+            </div>
+        </div>
+
         <!-- Elements for attribute-only modal save detection tests (isolated) -->
         <div class="test-section">
             <a href="https://example.com" data-scms-link="attr-save-link">Attr Save Link</a>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -219,6 +219,17 @@
             </div>
         </div>
 
+        <!-- Template for undo tests (isolated) -->
+        <div class="test-section">
+            <h2>Team Undo Test</h2>
+            <div data-scms-template="team-undo" class="team-container">
+                <div class="team-member">
+                    <h3 data-scms-text="name">Default Name</h3>
+                    <p data-scms-text="role">Default Role</p>
+                </div>
+            </div>
+        </div>
+
         <!-- Template for pending-deletes tests (isolated) -->
         <div class="test-section">
             <h2>Team Pending Deletes Test</h2>

--- a/tests/browser/support/sdk-helpers.ts
+++ b/tests/browser/support/sdk-helpers.ts
@@ -27,7 +27,8 @@ export function getController(): EditorController | null {
  */
 export function generateTestAppId(): string {
     const counter = initCounter++;
-    return `test-app-${Date.now()}-${counter}`;
+    const random = Math.random().toString(36).slice(2, 8);
+    return `test-app-${Date.now()}-${counter}-${random}`;
 }
 
 /**

--- a/tests/browser/support/server.ts
+++ b/tests/browser/support/server.ts
@@ -307,7 +307,7 @@ export class TestServer {
                 const responseGroups: Record<string, { elements: Record<string, ContentElement> }> =
                     {};
                 const deletedElements: string[] = [];
-                const deletedGroups: Record<string, string[]> = {};
+                const deletedGroups: Record<string, { elements: string[] }> = {};
 
                 // Process ungrouped elements
                 if (data.elements) {
@@ -338,9 +338,9 @@ export class TestServer {
                                 // Delete
                                 this.contentStore.delete(key);
                                 if (!deletedGroups[groupId]) {
-                                    deletedGroups[groupId] = [];
+                                    deletedGroups[groupId] = { elements: [] };
                                 }
-                                deletedGroups[groupId].push(elementId);
+                                deletedGroups[groupId].elements.push(elementId);
                             } else {
                                 // Create/update
                                 const element: ContentElement = {


### PR DESCRIPTION
## Summary

- Fix multipage save deleting content from other pages (#76)
- Add undo/redo system for template instance deletion (#31)
- Add content viewer overlay for discovering editable elements
- Fix various template, save, and test reliability issues

## Changes

### Bug fixes
- Fix multipage save incorrectly deleting elements from other pages by switching from derived to explicit delete tracking via `pendingDeletes` set
- Fix template instance outline not clearing when selecting a non-template element
- Fix `elementIds is not iterable` when saving deleted grouped elements
- Fix attribute-only modal changes not updating `currentContent`
- Fix `stripTemplateContent` preserving inline elements inside editables
- Fix flaky tests caused by appId collisions between parallel test files

### Features
- **Undo/redo system**: Command-pattern `UndoManager` with dual stacks. Template instance deletion can be undone via toolbar button. Redo stack maintained for future use.
- **Content viewer overlay**: Discover and select editable elements with visual badges showing element types. Toggle via toolbar button.
- **Toolbar layout**: Moved content viewer button left of separator, added undo button to desktop and mobile layouts

### Refactoring
- Move `addInstanceWithId()` and `reorderInstances()` from DraftManager to TemplateManager
- Hide toolbar active element badge (too technical for users)

## Test plan
- [x] All 273 tests pass (`npm test`)
- [x] Prettier formatting clean (`npm run format:check`)
- [ ] Manual: edit on page A, save, verify page B content untouched
- [ ] Manual: delete template instance, click undo, verify content restored
- [ ] Manual: toggle content viewer, verify badges appear on editable elements