### PR TITLE
Fix deploy-prod PR lookup and release v1.1.0

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -27,24 +27,13 @@ jobs:
                       exit 0
                   fi
 
-                  # Get parent commits
-                  PARENTS=($(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}" --jq '.parents[].sha'))
-                  echo "Parent commits: ${PARENTS[*]}"
+                  # Look up PR associated with this merge commit
+                  echo "Looking up PR for merge commit: ${{ github.sha }}"
 
-                  if [ ${#PARENTS[@]} -ne 2 ]; then
-                      echo "Not a merge commit (${#PARENTS[@]} parent(s)), skipping deploy"
-                      echo "should_deploy=false" >> $GITHUB_OUTPUT
-                      exit 0
-                  fi
-
-                  # Parent 2 is the PR branch HEAD
-                  PR_BRANCH_SHA="${PARENTS[1]}"
-                  echo "Looking up PR for branch HEAD: $PR_BRANCH_SHA"
-
-                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/$PR_BRANCH_SHA/pulls" --jq '.[0]' 2>/dev/null || echo "")
+                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0]' 2>/dev/null || echo "")
 
                   if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "null" ]; then
-                      echo "::error::No PR found for commit $PR_BRANCH_SHA"
+                      echo "::error::No PR found for commit ${{ github.sha }}"
                       exit 1
                   fi
 


### PR DESCRIPTION
## Summary

- Fix deploy-prod workflow to look up PR via merge commit SHA instead of parent commit
- Release v1.1.0 (all changes from #78 are already on master, this adds the workflow fix and triggers the deploy)

## Workflow fix

The deploy-prod workflow was looking up the PR via the second parent of the merge commit, which fails when merging develop to master because that parent is itself a merge commit from a different PR. Using the merge commit SHA directly resolves this.