### PR TITLE
Add inline rich text editing with Tiptap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "dependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-link": "^3.22.1",
+        "@tiptap/extension-underline": "^3.22.1",
+        "@tiptap/pm": "^3.22.1",
+        "@tiptap/starter-kit": "^3.22.1",
         "@vue/reactivity": "^3.5.26",
         "driver.js": "^1.4.0",
         "lit": "^3.3.1",
@@ -1345,6 +1350,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -2071,6 +2082,379 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.1.tgz",
+      "integrity": "sha512-6wPNhkdLIGYiKAGqepDCRtR0TYGJxV40SwOEN2vlPhsXqAgzmyG37UyREj5pGH5xTekugqMCgCnyRg7m5nYoYQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.1.tgz",
+      "integrity": "sha512-omPsJ/IMAZYhXqOaEenYE+HA9U2zju5rQbAn6Xktynvr4A5P95jqkgAwncXB82pCkNYU/uYxi51vyTweTeEUHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.1.tgz",
+      "integrity": "sha512-0+q6Apu1Vx2+ReB2ktTpBrQ5/dCvGzTkJCy+MZ/t8WBcybqFXOKYRCr/i/VGPDpXZttxpk0EPl0+ao+NVcUTAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.1.tgz",
+      "integrity": "sha512-83L+4N2JziWORbWtlsM0xBm3LOKIw4YtIm+Kh4amV5kGvIgIL5I1KYzoxv20qjgFX2k08LtLMwPdvPSPSh4e7g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.1.tgz",
+      "integrity": "sha512-Ze+hjSLLCn+5gVpuE/Uv7mQ83AlG5A9OPsuDoyzTpJ2XNvZP2iZdwQMGqwXKC8eH7fIOJN6XQ3IDv/EhltQx/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.1.tgz",
+      "integrity": "sha512-fr3b1seFsAeYHtPAb9fbATkGcgyfStD05GHsZXFLh7yCpf2ejWLNxdWJT/g+FggSEHYFKCXT06aixk0WbtRcWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.1.tgz",
+      "integrity": "sha512-fBI/+PGtK6pzitqjSSSYL2+uZglX6T53zb5nLEmN/q8q7FzUuUpglp8toHVhBG05WDk4vx6Z7bC95uyxkYdoAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.1.tgz",
+      "integrity": "sha512-PuSNoTROZB564KpTG9ExVB3CsfRa0ridHx+1sWZajOBVZJiXSn4QlS/ShS509SOx8z17DyxEw06IH//OHY9XyQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.1.tgz",
+      "integrity": "sha512-qqsyy7unWM3elv+7ru+6paKAnw1PZTvjNVQu3UzB6d556Gx2uE4isXJNdBaslBZdp2EoaYdIkhhEccW9B/Nwqg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.1.tgz",
+      "integrity": "sha512-hzLwLEZVbZODa9q5UiCQpOUmDnyxN19FA4LhlqLP0/JSHewP/aol5igFZwuw0XVFp425BuzPjrB7tmr0GRTDWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.1.tgz",
+      "integrity": "sha512-EaIihzrOfXUHQlL6fFyJCkDrjgg0e/eD4jpkjhKpeuJDcqf7eJ1c0E2zcNRAiZkeXdN/hTQFaXKsSyNUE7T7Sg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.1.tgz",
+      "integrity": "sha512-Q18A8IN+gnfptIksPeVAI6oOBGYKAGf+QN0FEJ5OXO4BEAmA3hflflA1rWNfPC4aQNry/N7sAl8Gpd6HuIbz2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.1.tgz",
+      "integrity": "sha512-EXPZWEsWJK9tUMypddOBvayaBeu8wFV2uH5PNrtDKrfRZ1Bf8GQ3lfcO0blHssaQ9nWqa9HwBC1mdfWcmfpxig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.1.tgz",
+      "integrity": "sha512-RHch/Bqv+QDvW3J1CXmiTB54pyrQYNQq8Vfa7is/O209dNPA8tdbkRP44rDjqn8NeDCriC/oJ4avWeXL4qNDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.1.tgz",
+      "integrity": "sha512-6bVI5A12sFeyb0EngABV8/qCtC2IgiDbWC8mtNNLh5dAVGaUKo1KucL6vRYDhzXhyO/eHuGYepXZDLOOdS9LIQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.1.tgz",
+      "integrity": "sha512-v0FgSX3cqLY3L1hIe2PFRTR3/+wlFOdFjv0p3fSJ5Tl7cgU7DR1OcljFqpw0exePcmt6dXqXVQua3PxSVV15eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.1.tgz",
+      "integrity": "sha512-00Nz4jJygYGJg6N1mdbQUslFG9QaGZq5P9MFwqoduWku7gYHWkZoZvrkxZrYtxGTHVIlLnF8LIfblAlOwNd76g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.1.tgz",
+      "integrity": "sha512-sbd99ZUa1lIemH7N6dLB+9aYxUgduwW2216VM3dLJBS9hmTA4iDRxWx0a1ApnAVv+sZasRSbb/wpYLtXviA1XQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.1.tgz",
+      "integrity": "sha512-mnvGEZfZFysHGvmEqrSLjeddaNPB3UmomTInv9gsImw8hlB4/gQedvB6Qf2tFfIjl4ISKC5AbFxraSnJfjaL5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.1.tgz",
+      "integrity": "sha512-LTdnGmglK1f/AW//36k+Km8URA1wrTLENi3R5N+/ipv+yP2rZ2Ki1R1m6yJx3KSFzR55c91xE6659/vz1uZ6iA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.1.tgz",
+      "integrity": "sha512-wFCNCATSTTFhvA9wOPkAgzPVyG3RM6+jOlDeRhHUCHsFWFWj0w9ZPwA/nP+Qi5hEW7kGG9V8o62RjBdHNvK2PQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.1.tgz",
+      "integrity": "sha512-p8/ErqQInWJbpncBycIggmtCjdrMwHmA3GNhOugo6F4fYfeVxgy7pVb7ZF+ss62d0mpQvEd81pyrzhkBtb0nBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.1.tgz",
+      "integrity": "sha512-BKpp371Pl1CVcLRLrWH7PC1I+IsXOhet80+pILqCMlwkJnsVtOOVRr5uCF6rbPP4xK5H/ehkQWmxA8rqpv42aA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.1.tgz",
+      "integrity": "sha512-OSqSg2974eLJT5PNKFLM7156lBXCUf/dsKTQXWSzsLTf6HOP4dYP6c0YbAk6lgbNI+BdszsHNClmLVLA8H/L9A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.1.tgz",
+      "integrity": "sha512-1fFmURkgofxgP9GW993bSpxf2rIJzQbWZ9rPw17qbAVuGouIArG+Fd/A1WUD95Vdbx6JIrc1QxbNlLs7bhcoPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-blockquote": "^3.22.1",
+        "@tiptap/extension-bold": "^3.22.1",
+        "@tiptap/extension-bullet-list": "^3.22.1",
+        "@tiptap/extension-code": "^3.22.1",
+        "@tiptap/extension-code-block": "^3.22.1",
+        "@tiptap/extension-document": "^3.22.1",
+        "@tiptap/extension-dropcursor": "^3.22.1",
+        "@tiptap/extension-gapcursor": "^3.22.1",
+        "@tiptap/extension-hard-break": "^3.22.1",
+        "@tiptap/extension-heading": "^3.22.1",
+        "@tiptap/extension-horizontal-rule": "^3.22.1",
+        "@tiptap/extension-italic": "^3.22.1",
+        "@tiptap/extension-link": "^3.22.1",
+        "@tiptap/extension-list": "^3.22.1",
+        "@tiptap/extension-list-item": "^3.22.1",
+        "@tiptap/extension-list-keymap": "^3.22.1",
+        "@tiptap/extension-ordered-list": "^3.22.1",
+        "@tiptap/extension-paragraph": "^3.22.1",
+        "@tiptap/extension-strike": "^3.22.1",
+        "@tiptap/extension-text": "^3.22.1",
+        "@tiptap/extension-underline": "^3.22.1",
+        "@tiptap/extensions": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -2104,6 +2488,28 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/resolve": {
@@ -2412,6 +2818,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2783,6 +3195,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
@@ -3313,6 +3731,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -4124,6 +4554,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/lit": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
@@ -4243,6 +4688,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4259,6 +4733,12 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -4443,6 +4923,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
     "node_modules/p-finally": {
@@ -5272,11 +5758,215 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
+      "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
+      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5418,6 +6108,12 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -5962,6 +6658,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
@@ -6187,6 +6889,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
     "wrangler": "^4.58.0"
   },
   "dependencies": {
+    "@tiptap/core": "^3.22.1",
+    "@tiptap/extension-link": "^3.22.1",
+    "@tiptap/extension-underline": "^3.22.1",
+    "@tiptap/pm": "^3.22.1",
+    "@tiptap/starter-kit": "^3.22.1",
     "@vue/reactivity": "^3.5.26",
     "driver.js": "^1.4.0",
     "lit": "^3.3.1",

--- a/src/components/accessibility-modal.ts
+++ b/src/components/accessibility-modal.ts
@@ -335,14 +335,7 @@ export class AccessibilityModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Accessibility</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Accessibility</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/attributes-modal.ts
+++ b/src/components/attributes-modal.ts
@@ -428,14 +428,7 @@ export class AttributesModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Custom Attributes</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Custom Attributes</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/html-editor-modal.ts
+++ b/src/components/html-editor-modal.ts
@@ -144,14 +144,7 @@ export class HtmlEditorModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Edit HTML</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">View Source</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -140,10 +140,7 @@ export class LinkEditorModal extends ScmsElement {
     }
 
     private hasChanges(): boolean {
-        return (
-            this.editedHref !== this.linkData.href ||
-            this.editedTarget !== this.linkData.target
-        );
+        return this.editedHref !== this.linkData.href || this.editedTarget !== this.linkData.target;
     }
 
     private handleBackdropClick(e: Event) {

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -108,11 +108,6 @@ export class LinkEditorModal extends ScmsElement {
         this.editedTarget = select.value;
     }
 
-    private handleValueInput(e: Event) {
-        const textarea = e.target as HTMLTextAreaElement;
-        this.editedValue = textarea.value;
-    }
-
     private handleApply() {
         this.dispatchEvent(
             new CustomEvent("apply", {

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -147,8 +147,7 @@ export class LinkEditorModal extends ScmsElement {
     private hasChanges(): boolean {
         return (
             this.editedHref !== this.linkData.href ||
-            this.editedTarget !== this.linkData.target ||
-            this.editedValue !== this.linkData.value
+            this.editedTarget !== this.linkData.target
         );
     }
 
@@ -176,14 +175,7 @@ export class LinkEditorModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Edit Link</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Edit Link</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}
@@ -202,20 +194,6 @@ export class LinkEditorModal extends ScmsElement {
 
                 <!-- Form -->
                 <div class="p-4 space-y-4">
-                    <!-- Link Content -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">
-                            Link Content (HTML)
-                        </label>
-                        <textarea
-                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-gray-400 focus:border-gray-400 font-mono text-sm"
-                            rows="3"
-                            .value=${this.editedValue}
-                            @input=${this.handleValueInput}
-                            placeholder="Click here"
-                        ></textarea>
-                    </div>
-
                     <!-- URL -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1"> URL </label>

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -55,6 +55,9 @@ export class FormattingToolbar extends ScmsElement {
     private activeFormats: Set<string> = new Set();
 
     @state()
+    private isMobile = false;
+
+    @state()
     private posX = -1;
 
     @state()
@@ -76,6 +79,35 @@ export class FormattingToolbar extends ScmsElement {
     private dragStartY = 0;
     private dragStartPosX = 0;
     private dragStartPosY = 0;
+
+    /** Clamp toolbar position to stay within the visual viewport (handles keyboard open/close). */
+    private handleViewportChange = () => {
+        this.isMobile = window.innerWidth < 640;
+
+        const vv = window.visualViewport;
+        if (!vv) return;
+
+        const toolbar = this.shadowRoot?.querySelector(".toolbar-container") as HTMLElement | null;
+        const toolbarHeight = toolbar?.offsetHeight ?? 48;
+        const toolbarWidth = toolbar?.offsetWidth ?? 200;
+
+        const visibleTop = vv.offsetTop;
+        const visibleBottom = vv.offsetTop + vv.height;
+        const visibleRight = vv.offsetLeft + vv.width;
+
+        const maxY = visibleBottom - toolbarHeight;
+        const clampedY = Math.max(visibleTop, Math.min(this.posY, maxY));
+
+        let clampedX = this.posX;
+        if (!this.isMobile && this.posX !== -1) {
+            const maxX = visibleRight - toolbarWidth;
+            clampedX = Math.max(vv.offsetLeft, Math.min(this.posX, maxX));
+        }
+
+        if (clampedY !== this.posY) this.posY = clampedY;
+        if (clampedX !== this.posX) this.posX = clampedX;
+    };
+
     /**
      * Callback fired on each content update. Set by the controller
      * to sync content changes back to the content manager.
@@ -94,7 +126,8 @@ export class FormattingToolbar extends ScmsElement {
 
             .toolbar-container {
                 pointer-events: auto;
-                display: inline-flex;
+                display: flex;
+                flex-direction: column;
                 align-items: center;
                 gap: 2px;
                 padding: 4px 8px;
@@ -104,17 +137,27 @@ export class FormattingToolbar extends ScmsElement {
                 box-shadow:
                     0 4px 6px -1px rgba(0, 0, 0, 0.1),
                     0 2px 4px -2px rgba(0, 0, 0, 0.1);
+            }
+
+            .toolbar-buttons {
+                display: flex;
                 flex-wrap: wrap;
+                justify-content: center;
+                align-items: center;
+                gap: 2px;
             }
 
             .drag-handle {
                 cursor: grab;
-                padding: 4px 2px;
+                padding: 2px 0;
                 color: #9ca3af;
                 display: flex;
                 align-items: center;
+                justify-content: center;
+                width: 40px;
                 user-select: none;
                 -webkit-user-select: none;
+                touch-action: none;
             }
 
             .drag-handle:active {
@@ -134,6 +177,7 @@ export class FormattingToolbar extends ScmsElement {
      */
     attach(element: HTMLElement, linkMode: boolean): void {
         this.linkMode = linkMode;
+        this.isMobile = window.innerWidth < 640;
         this.targetElement = element;
 
         // Reuse existing editor for this element
@@ -271,10 +315,17 @@ export class FormattingToolbar extends ScmsElement {
         }
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        window.visualViewport?.addEventListener("resize", this.handleViewportChange);
+        window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
+    }
+
     disconnectedCallback() {
         super.disconnectedCallback();
+        window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
+        window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
         this.detach();
-
     }
 
     private updateActiveFormats() {
@@ -309,8 +360,25 @@ export class FormattingToolbar extends ScmsElement {
         const onMove = (ev: PointerEvent) => {
             const dx = ev.clientX - this.dragStartX;
             const dy = ev.clientY - this.dragStartY;
-            this.posX = Math.max(0, this.dragStartPosX + dx);
-            this.posY = Math.max(0, this.dragStartPosY + dy);
+
+            const toolbar = this.shadowRoot?.querySelector(
+                ".toolbar-container",
+            ) as HTMLElement | null;
+            const toolbarHeight = toolbar?.offsetHeight ?? 48;
+            const toolbarWidth = toolbar?.offsetWidth ?? 200;
+
+            const vv = window.visualViewport;
+            const minY = vv?.offsetTop ?? 0;
+            const maxY = (vv ? vv.offsetTop + vv.height : window.innerHeight) - toolbarHeight;
+
+            this.posY = Math.max(minY, Math.min(this.dragStartPosY + dy, maxY));
+
+            if (!this.isMobile) {
+                const minX = vv?.offsetLeft ?? 0;
+                const maxX =
+                    (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
+                this.posX = Math.max(minX, Math.min(this.dragStartPosX + dx, maxX));
+            }
         };
 
         const onUp = () => {
@@ -440,53 +508,62 @@ export class FormattingToolbar extends ScmsElement {
         return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
     }
 
+    private renderDragHandle() {
+        return html`
+            <div
+                class="drag-handle"
+                @pointerdown=${this.handleDragStart}
+                title="Drag to reposition"
+            >
+                <span class="[&>svg]:w-4 [&>svg]:h-4">
+                    ${unsafeSVG(GripHorizontal)}
+                </span>
+            </div>
+        `;
+    }
+
     render() {
         if (!this.editor) return nothing;
 
-        const left = this.posX === -1 ? "50%" : `${this.posX}px`;
-        const transform = this.posX === -1 ? "translateX(-50%)" : "none";
+        const mobile = this.isMobile;
+        const left = mobile ? "0" : this.posX === -1 ? "50%" : `${this.posX}px`;
+        const right = mobile ? "0" : "auto";
+        const transform = !mobile && this.posX === -1 ? "translateX(-50%)" : "none";
 
         return html`
             <div
                 class="toolbar-container"
-                style="position:fixed; top:${this.posY}px; left:${left}; transform:${transform};"
+                style="position:fixed; top:${this.posY}px; left:${left}; right:${right}; transform:${transform};"
             >
-                <div
-                    class="drag-handle"
-                    @pointerdown=${this.handleDragStart}
-                    title="Drag to reposition"
-                >
-                    <span class="[&>svg]:w-4 [&>svg]:h-4">
-                        ${unsafeSVG(GripHorizontal)}
-                    </span>
+                ${this.renderDragHandle()}
+                <div class="toolbar-buttons">
+                    ${this.renderButton("bold", Bold, "Bold")}
+                    ${this.renderButton("italic", Italic, "Italic")}
+                    ${this.renderButton("underline", UnderlineIcon, "Underline")}
+                    ${this.renderButton("strike", Strikethrough, "Strikethrough")}
+                    ${this.renderButton("code", Code, "Inline Code")}
+                    ${this.renderSeparator()}
+                    ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
+                    ${this.renderButton("h1", Heading1, "Heading 1")}
+                    ${this.renderButton("h2", Heading2, "Heading 2")}
+                    ${this.renderButton("h3", Heading3, "Heading 3")}
+                    ${this.linkMode
+                        ? nothing
+                        : html`
+                              ${this.renderSeparator()}
+                              ${this.renderButton("bulletList", List, "Bullet List")}
+                              ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
+                              ${this.renderButton("blockquote", Quote, "Blockquote")}
+                          `}
+                    ${this.linkMode ? nothing : this.renderSeparator()}
+                    ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                    ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.linkMode ? this.renderSeparator() : nothing}
+                    ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
+                    ${this.renderSeparator()}
+                    ${this.renderButton("undo", Undo2, "Undo")}
+                    ${this.renderButton("redo", Redo2, "Redo")}
                 </div>
-                ${this.renderSeparator()}
-                ${this.renderButton("bold", Bold, "Bold")}
-                ${this.renderButton("italic", Italic, "Italic")}
-                ${this.renderButton("underline", UnderlineIcon, "Underline")}
-                ${this.renderButton("strike", Strikethrough, "Strikethrough")}
-                ${this.renderButton("code", Code, "Inline Code")}
-                ${this.renderSeparator()}
-                ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
-                ${this.renderButton("h1", Heading1, "Heading 1")}
-                ${this.renderButton("h2", Heading2, "Heading 2")}
-                ${this.renderButton("h3", Heading3, "Heading 3")}
-                ${this.linkMode
-                    ? nothing
-                    : html`
-                          ${this.renderSeparator()}
-                          ${this.renderButton("bulletList", List, "Bullet List")}
-                          ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
-                          ${this.renderButton("blockquote", Quote, "Blockquote")}
-                      `}
-                ${this.linkMode ? nothing : this.renderSeparator()}
-                ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
-                ${this.linkMode ? this.renderSeparator() : nothing}
-                ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
-                ${this.renderSeparator()}
-                ${this.renderButton("undo", Undo2, "Undo")}
-                ${this.renderButton("redo", Redo2, "Redo")}
             </div>
         `;
     }

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -242,10 +242,7 @@ export class FormattingToolbar extends ScmsElement {
                     ".toolbar-container",
                 ) as HTMLElement | null;
                 if (toolbar) {
-                    this.posX = Math.max(
-                        12,
-                        (window.innerWidth - toolbar.offsetWidth) / 2,
-                    );
+                    this.posX = Math.max(12, (window.innerWidth - toolbar.offsetWidth) / 2);
                 }
             });
         }
@@ -384,8 +381,7 @@ export class FormattingToolbar extends ScmsElement {
 
             if (!this.isMobile) {
                 const minX = vv?.offsetLeft ?? 0;
-                const maxX =
-                    (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
+                const maxX = (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
                 this.posX = Math.max(minX, Math.min(this.dragStartPosX + dx, maxX));
             }
         };
@@ -463,9 +459,7 @@ export class FormattingToolbar extends ScmsElement {
                 break;
             case "link": {
                 const currentHref = this.editor.getAttributes("link").href || "";
-                const message = currentHref
-                    ? "Edit URL (clear to remove link):"
-                    : "Enter URL:";
+                const message = currentHref ? "Edit URL (clear to remove link):" : "Enter URL:";
                 const href = prompt(message, currentHref);
                 if (href === null) {
                     // User cancelled — do nothing
@@ -524,9 +518,7 @@ export class FormattingToolbar extends ScmsElement {
                 @pointerdown=${this.handleDragStart}
                 title="Drag to reposition"
             >
-                <span class="[&>svg]:w-4 [&>svg]:h-4">
-                    ${unsafeSVG(GripHorizontal)}
-                </span>
+                <span class="[&>svg]:w-4 [&>svg]:h-4"> ${unsafeSVG(GripHorizontal)} </span>
             </div>
         `;
     }
@@ -542,7 +534,8 @@ export class FormattingToolbar extends ScmsElement {
         return html`
             <div
                 class="toolbar-container"
-                style="position:fixed; top:${this.posY}px; left:${left}; right:${right}; transform:${transform};"
+                style="position:fixed; top:${this
+                    .posY}px; left:${left}; right:${right}; transform:${transform};"
             >
                 ${this.renderDragHandle()}
                 <div class="toolbar-buttons">
@@ -550,8 +543,7 @@ export class FormattingToolbar extends ScmsElement {
                     ${this.renderButton("italic", Italic, "Italic")}
                     ${this.renderButton("underline", UnderlineIcon, "Underline")}
                     ${this.renderButton("strike", Strikethrough, "Strikethrough")}
-                    ${this.renderButton("code", Code, "Inline Code")}
-                    ${this.renderSeparator()}
+                    ${this.renderButton("code", Code, "Inline Code")} ${this.renderSeparator()}
                     ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
                     ${this.renderButton("h1", Heading1, "Heading 1")}
                     ${this.renderButton("h2", Heading2, "Heading 2")}
@@ -566,11 +558,14 @@ export class FormattingToolbar extends ScmsElement {
                           `}
                     ${this.linkMode ? nothing : this.renderSeparator()}
                     ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                    ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.linkMode
+                        ? nothing
+                        : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
                     ${this.linkMode ? this.renderSeparator() : nothing}
-                    ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
-                    ${this.renderSeparator()}
-                    ${this.renderButton("undo", Undo2, "Undo")}
+                    ${this.linkMode
+                        ? this.renderButton("goToLink", ExternalLink, "Go to Link")
+                        : nothing}
+                    ${this.renderSeparator()} ${this.renderButton("undo", Undo2, "Undo")}
                     ${this.renderButton("redo", Redo2, "Redo")}
                 </div>
             </div>

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -186,6 +186,13 @@ export class FormattingToolbar extends ScmsElement {
         if (existing) {
             this.editor = existing.editor;
             this.initialHTML = existing.initialHTML;
+            // Defensive: ensure the element is still editable. Something can
+            // leave contenteditable=false on a tiptap-managed element, which
+            // hides the cursor and blocks typing even though the editor and
+            // toolbar are still alive.
+            if (element.getAttribute("contenteditable") !== "true") {
+                element.setAttribute("contenteditable", "true");
+            }
             this.editor.commands.focus();
             this.updateActiveFormats();
             this.style.display = "block";

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -1,0 +1,495 @@
+/**
+ * Rich Text Editor Component
+ *
+ * A shared WYSIWYG editor built on Tiptap (ProseMirror).
+ * Used by both the HTML editor modal and link editor modal.
+ * Supports full and compact toolbar modes, plus a raw HTML source toggle.
+ */
+
+import { html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { ScmsElement } from "./base.js";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import Underline from "@tiptap/extension-underline";
+import {
+    Bold,
+    Italic,
+    Underline as UnderlineIcon,
+    Strikethrough,
+    Code,
+    Heading1,
+    Heading2,
+    Heading3,
+    List,
+    ListOrdered,
+    Quote,
+    Link as LinkIcon,
+    Minus,
+    Undo2,
+    Redo2,
+    Code2,
+} from "lucide-static";
+
+@customElement("scms-rich-text-editor")
+export class RichTextEditor extends ScmsElement {
+    @property({ type: String })
+    content = "";
+
+    @property({ type: Boolean })
+    compact = false;
+
+    @state()
+    private sourceMode = false;
+
+    @state()
+    private sourceContent = "";
+
+    @state()
+    private activeFormats: Set<string> = new Set();
+
+    private editor: Editor | null = null;
+    private initialHTML = "";
+
+    static styles = [
+        ...ScmsElement.styles,
+        css`
+            .editor-wrapper {
+                border: 1px solid #d1d5db;
+                border-radius: 0.375rem;
+                overflow: hidden;
+            }
+
+            .editor-wrapper:focus-within {
+                border-color: #9ca3af;
+                box-shadow: 0 0 0 1px #9ca3af;
+            }
+
+            .ProseMirror {
+                outline: none;
+                padding: 0.75rem;
+                font-size: 14px;
+                line-height: 1.6;
+            }
+
+            :host([compact]) .ProseMirror {
+                min-height: 80px;
+                max-height: 200px;
+                overflow-y: auto;
+            }
+
+            :host(:not([compact])) .ProseMirror {
+                min-height: 200px;
+                max-height: 50vh;
+                overflow-y: auto;
+            }
+
+            .ProseMirror p {
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror h1 {
+                font-size: 1.5em;
+                font-weight: 700;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror h2 {
+                font-size: 1.25em;
+                font-weight: 600;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror h3 {
+                font-size: 1.1em;
+                font-weight: 600;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror ul {
+                list-style: disc;
+                padding-left: 1.5em;
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror ol {
+                list-style: decimal;
+                padding-left: 1.5em;
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror li {
+                margin: 0.1em 0;
+            }
+
+            .ProseMirror blockquote {
+                border-left: 3px solid #d1d5db;
+                padding-left: 1em;
+                color: #6b7280;
+                margin: 0.5em 0;
+            }
+
+            .ProseMirror a {
+                color: #2563eb;
+                text-decoration: underline;
+            }
+
+            .ProseMirror code {
+                background: #f3f4f6;
+                padding: 0.15em 0.35em;
+                border-radius: 0.25em;
+                font-size: 0.875em;
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                    monospace;
+            }
+
+            .ProseMirror hr {
+                border: none;
+                border-top: 1px solid #d1d5db;
+                margin: 1em 0;
+            }
+
+            .ProseMirror p.is-editor-empty:first-child::before {
+                content: attr(data-placeholder);
+                color: #9ca3af;
+                pointer-events: none;
+                float: left;
+                height: 0;
+            }
+
+            .source-textarea {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                    monospace;
+                font-size: 13px;
+                line-height: 1.5;
+                tab-size: 2;
+                padding: 0.75rem;
+                width: 100%;
+                border: none;
+                outline: none;
+                resize: none;
+            }
+
+            :host([compact]) .source-textarea {
+                min-height: 80px;
+                max-height: 200px;
+            }
+
+            :host(:not([compact])) .source-textarea {
+                min-height: 200px;
+                max-height: 50vh;
+            }
+
+            button {
+                cursor: pointer;
+            }
+        `,
+    ];
+
+    firstUpdated() {
+        const editorElement = this.shadowRoot!.querySelector("#editor") as HTMLElement;
+        if (!editorElement) return;
+
+        this.editor = new Editor({
+            element: editorElement,
+            extensions: [
+                StarterKit.configure({
+                    heading: this.compact ? false : { levels: [1, 2, 3] },
+                    bulletList: this.compact ? false : undefined,
+                    orderedList: this.compact ? false : undefined,
+                    blockquote: this.compact ? false : undefined,
+                    horizontalRule: this.compact ? false : undefined,
+                    strike: this.compact ? false : undefined,
+                    code: this.compact ? false : undefined,
+                }),
+                Link.configure({
+                    openOnClick: false,
+                    HTMLAttributes: {
+                        rel: null,
+                        target: null,
+                    },
+                }),
+                Underline,
+            ],
+            content: this.content,
+            onTransaction: () => {
+                this.updateActiveFormats();
+                this.dispatchEvent(
+                    new CustomEvent("content-change", {
+                        detail: { content: this.editor!.getHTML() },
+                        bubbles: true,
+                        composed: true,
+                    }),
+                );
+            },
+        });
+
+        this.initialHTML = this.editor.getHTML();
+        this.updateActiveFormats();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this.editor?.destroy();
+        this.editor = null;
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        if (changedProperties.has("content") && this.editor) {
+            const currentHTML = this.editor.getHTML();
+            if (currentHTML !== this.content) {
+                this.editor.commands.setContent(this.content, { emitUpdate: false });
+            }
+        }
+    }
+
+    /**
+     * Get the current editor content as HTML
+     */
+    getHTML(): string {
+        if (this.sourceMode) {
+            return this.sourceContent;
+        }
+        return this.editor?.getHTML() || this.content;
+    }
+
+    /**
+     * Whether the editor content has changed from what was initially loaded.
+     * Compares against Tiptap-normalized HTML to avoid false positives from
+     * normalization (e.g. "Hello" → "<p>Hello</p>").
+     */
+    hasChanges(): boolean {
+        return this.getHTML() !== this.initialHTML;
+    }
+
+    private updateActiveFormats() {
+        if (!this.editor) return;
+
+        const formats = new Set<string>();
+        if (this.editor.isActive("bold")) formats.add("bold");
+        if (this.editor.isActive("italic")) formats.add("italic");
+        if (this.editor.isActive("underline")) formats.add("underline");
+        if (this.editor.isActive("strike")) formats.add("strike");
+        if (this.editor.isActive("code")) formats.add("code");
+        if (this.editor.isActive("heading", { level: 1 })) formats.add("h1");
+        if (this.editor.isActive("heading", { level: 2 })) formats.add("h2");
+        if (this.editor.isActive("heading", { level: 3 })) formats.add("h3");
+        if (this.editor.isActive("bulletList")) formats.add("bulletList");
+        if (this.editor.isActive("orderedList")) formats.add("orderedList");
+        if (this.editor.isActive("blockquote")) formats.add("blockquote");
+        if (this.editor.isActive("link")) formats.add("link");
+
+        this.activeFormats = formats;
+    }
+
+    private toggleSourceMode() {
+        if (this.sourceMode) {
+            // Switching back to rich text: apply source content to editor
+            if (this.editor) {
+                this.editor.commands.setContent(this.sourceContent, { emitUpdate: false });
+            }
+            this.sourceMode = false;
+        } else {
+            // Switching to source: capture editor HTML
+            this.sourceContent = this.editor?.getHTML() || this.content;
+            this.sourceMode = true;
+        }
+    }
+
+    private handleSourceInput(e: Event) {
+        const textarea = e.target as HTMLTextAreaElement;
+        this.sourceContent = textarea.value;
+        this.dispatchEvent(
+            new CustomEvent("content-change", {
+                detail: { content: this.sourceContent },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private exec(command: string, options?: Record<string, unknown>) {
+        if (!this.editor) return;
+        const chain = this.editor.chain().focus();
+
+        switch (command) {
+            case "bold":
+                chain.toggleBold().run();
+                break;
+            case "italic":
+                chain.toggleItalic().run();
+                break;
+            case "underline":
+                chain.toggleUnderline().run();
+                break;
+            case "strike":
+                chain.toggleStrike().run();
+                break;
+            case "code":
+                chain.toggleCode().run();
+                break;
+            case "h1":
+                chain.toggleHeading({ level: 1 }).run();
+                break;
+            case "h2":
+                chain.toggleHeading({ level: 2 }).run();
+                break;
+            case "h3":
+                chain.toggleHeading({ level: 3 }).run();
+                break;
+            case "bulletList":
+                chain.toggleBulletList().run();
+                break;
+            case "orderedList":
+                chain.toggleOrderedList().run();
+                break;
+            case "blockquote":
+                chain.toggleBlockquote().run();
+                break;
+            case "horizontalRule":
+                chain.setHorizontalRule().run();
+                break;
+            case "link": {
+                if (this.editor.isActive("link")) {
+                    chain.unsetLink().run();
+                } else {
+                    const url = options?.href as string | undefined;
+                    const href = url || prompt("Enter URL:");
+                    if (href) {
+                        chain.setLink({ href }).run();
+                    }
+                }
+                break;
+            }
+            case "undo":
+                chain.undo().run();
+                break;
+            case "redo":
+                chain.redo().run();
+                break;
+        }
+    }
+
+    private renderToolbarButton(
+        command: string,
+        icon: string,
+        title: string,
+        options?: Record<string, unknown>,
+    ) {
+        const isActive = this.activeFormats.has(command);
+        return html`
+            <button
+                type="button"
+                class="p-1.5 rounded transition-colors ${isActive
+                    ? "bg-gray-200 text-gray-900"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
+                title=${title}
+                @click=${() => this.exec(command, options)}
+            >
+                <span class="[&>svg]:w-4 [&>svg]:h-4 flex items-center justify-center">
+                    ${unsafeSVG(icon)}
+                </span>
+            </button>
+        `;
+    }
+
+    private renderSeparator() {
+        return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
+    }
+
+    private renderToolbar() {
+        if (this.compact) {
+            return html`
+                <div
+                    class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+                >
+                    <div class="flex items-center gap-0.5">
+                        ${this.renderToolbarButton("bold", Bold, "Bold")}
+                        ${this.renderToolbarButton("italic", Italic, "Italic")}
+                        ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
+                        ${this.renderSeparator()}
+                        ${this.renderToolbarButton("link", LinkIcon, "Link")}
+                    </div>
+                    <div class="flex-1"></div>
+                    ${this.renderSourceToggle()}
+                </div>
+            `;
+        }
+
+        return html`
+            <div
+                class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+            >
+                <div class="flex items-center gap-0.5">
+                    ${this.renderToolbarButton("bold", Bold, "Bold")}
+                    ${this.renderToolbarButton("italic", Italic, "Italic")}
+                    ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
+                    ${this.renderToolbarButton("strike", Strikethrough, "Strikethrough")}
+                    ${this.renderToolbarButton("code", Code, "Inline Code")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("h1", Heading1, "Heading 1")}
+                    ${this.renderToolbarButton("h2", Heading2, "Heading 2")}
+                    ${this.renderToolbarButton("h3", Heading3, "Heading 3")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("bulletList", List, "Bullet List")}
+                    ${this.renderToolbarButton("orderedList", ListOrdered, "Ordered List")}
+                    ${this.renderToolbarButton("blockquote", Quote, "Blockquote")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("link", LinkIcon, "Link")}
+                    ${this.renderToolbarButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("undo", Undo2, "Undo")}
+                    ${this.renderToolbarButton("redo", Redo2, "Redo")}
+                </div>
+                <div class="flex-1"></div>
+                ${this.renderSourceToggle()}
+            </div>
+        `;
+    }
+
+    private renderSourceToggle() {
+        return html`
+            <button
+                type="button"
+                class="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${this
+                    .sourceMode
+                    ? "bg-gray-200 text-gray-900"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
+                title=${this.sourceMode ? "Switch to rich text" : "View HTML source"}
+                @click=${this.toggleSourceMode}
+            >
+                <span class="[&>svg]:w-3.5 [&>svg]:h-3.5 flex items-center">
+                    ${unsafeSVG(Code2)}
+                </span>
+                ${this.sourceMode ? "Rich Text" : "Source"}
+            </button>
+        `;
+    }
+
+    render() {
+        return html`
+            <div class="editor-wrapper">
+                ${this.renderToolbar()}
+                <div id="editor" style=${this.sourceMode ? "display:none" : nothing}></div>
+                ${this.sourceMode
+                    ? html`
+                          <textarea
+                              class="source-textarea"
+                              .value=${this.sourceContent}
+                              @input=${this.handleSourceInput}
+                              spellcheck="false"
+                          ></textarea>
+                      `
+                    : nothing}
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "scms-rich-text-editor": RichTextEditor;
+    }
+}

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -5,7 +5,7 @@
  * Mounts Tiptap directly on the page element being edited, providing
  * inline rich text formatting with clean HTML output.
  * Positioned fixed at the top of the viewport with a detached/hovering look.
- * Supports full and compact toolbar modes, and is draggable.
+ * Supports full and link toolbar modes, and is draggable.
  *
  * Uses custom schema extensions to prevent HTML normalization on load.
  * See src/extensions/tiptap-schema.ts for details.
@@ -38,6 +38,8 @@ import {
     ListOrdered,
     Quote,
     Link as LinkIcon,
+    ExternalLink,
+    Pilcrow,
     Minus,
     Undo2,
     Redo2,
@@ -47,7 +49,7 @@ import {
 @customElement("scms-formatting-toolbar")
 export class FormattingToolbar extends ScmsElement {
     @property({ type: Boolean })
-    compact = false;
+    linkMode = false;
 
     @state()
     private activeFormats: Set<string> = new Set();
@@ -130,8 +132,8 @@ export class FormattingToolbar extends ScmsElement {
      * Reuses existing editor for the same element (preserves undo history).
      * Creates a new editor for new elements without destroying others.
      */
-    attach(element: HTMLElement, compact: boolean): void {
-        this.compact = compact;
+    attach(element: HTMLElement, linkMode: boolean): void {
+        this.linkMode = linkMode;
         this.targetElement = element;
 
         // Reuse existing editor for this element
@@ -287,6 +289,7 @@ export class FormattingToolbar extends ScmsElement {
         if (this.editor.isActive("heading", { level: 1 })) formats.add("h1");
         if (this.editor.isActive("heading", { level: 2 })) formats.add("h2");
         if (this.editor.isActive("heading", { level: 3 })) formats.add("h3");
+        if (this.editor.isActive("paragraph")) formats.add("paragraph");
         if (this.editor.isActive("bulletList")) formats.add("bulletList");
         if (this.editor.isActive("orderedList")) formats.add("orderedList");
         if (this.editor.isActive("blockquote")) formats.add("blockquote");
@@ -342,13 +345,32 @@ export class FormattingToolbar extends ScmsElement {
                 chain.toggleCode().run();
                 break;
             case "h1":
-                chain.toggleHeading({ level: 1 }).run();
+                if (this.editor.isActive("heading", { level: 1 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 1 }).run();
+                }
                 break;
             case "h2":
-                chain.toggleHeading({ level: 2 }).run();
+                if (this.editor.isActive("heading", { level: 2 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 2 }).run();
+                }
                 break;
             case "h3":
-                chain.toggleHeading({ level: 3 }).run();
+                if (this.editor.isActive("heading", { level: 3 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 3 }).run();
+                }
+                break;
+            case "paragraph":
+                if (this.editor.isActive("paragraph")) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setNode("paragraph").run();
+                }
                 break;
             case "bulletList":
                 chain.toggleBulletList().run();
@@ -379,6 +401,11 @@ export class FormattingToolbar extends ScmsElement {
                 }
                 break;
             }
+            case "goToLink":
+                if (this.targetElement instanceof HTMLAnchorElement) {
+                    window.open(this.targetElement.href, "_blank");
+                }
+                return;
             case "undo":
                 chain.undo().run();
                 break;
@@ -440,10 +467,11 @@ export class FormattingToolbar extends ScmsElement {
                 ${this.renderButton("strike", Strikethrough, "Strikethrough")}
                 ${this.renderButton("code", Code, "Inline Code")}
                 ${this.renderSeparator()}
+                ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
                 ${this.renderButton("h1", Heading1, "Heading 1")}
                 ${this.renderButton("h2", Heading2, "Heading 2")}
                 ${this.renderButton("h3", Heading3, "Heading 3")}
-                ${this.compact
+                ${this.linkMode
                     ? nothing
                     : html`
                           ${this.renderSeparator()}
@@ -451,9 +479,11 @@ export class FormattingToolbar extends ScmsElement {
                           ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
                           ${this.renderButton("blockquote", Quote, "Blockquote")}
                       `}
-                ${this.compact ? nothing : this.renderSeparator()}
-                ${this.compact ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                ${this.compact ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.linkMode ? nothing : this.renderSeparator()}
+                ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.linkMode ? this.renderSeparator() : nothing}
+                ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
                 ${this.renderSeparator()}
                 ${this.renderButton("undo", Undo2, "Undo")}
                 ${this.renderButton("redo", Redo2, "Redo")}

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -24,6 +24,7 @@ import {
     ListParagraph,
     FlexListItem,
     FlexBlockquote,
+    ParagraphSplitBlock,
 } from "../extensions/tiptap-schema.js";
 import {
     Bold,
@@ -209,6 +210,7 @@ export class FormattingToolbar extends ScmsElement {
                 ListParagraph,
                 FlexListItem,
                 FlexBlockquote,
+                ParagraphSplitBlock,
                 Link.configure({
                     openOnClick: false,
                     HTMLAttributes: { rel: null, target: null },

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -1,9 +1,14 @@
 /**
- * Rich Text Editor Component
+ * Formatting Toolbar Component
  *
- * A shared WYSIWYG editor built on Tiptap (ProseMirror).
- * Used by both the HTML editor modal and link editor modal.
- * Supports full and compact toolbar modes, plus a raw HTML source toggle.
+ * A floating WYSIWYG formatting toolbar powered by Tiptap (ProseMirror).
+ * Mounts Tiptap directly on the page element being edited, providing
+ * inline rich text formatting with clean HTML output.
+ * Positioned fixed at the top of the viewport with a detached/hovering look.
+ * Supports full and compact toolbar modes, and is draggable.
+ *
+ * Uses custom schema extensions to prevent HTML normalization on load.
+ * See src/extensions/tiptap-schema.ts for details.
  */
 
 import { html, css, nothing } from "lit";
@@ -13,7 +18,13 @@ import { ScmsElement } from "./base.js";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
+import {
+    SpanParagraph,
+    FlexDocument,
+    ListParagraph,
+    FlexListItem,
+    FlexBlockquote,
+} from "../extensions/tiptap-schema.js";
 import {
     Bold,
     Italic,
@@ -30,156 +41,82 @@ import {
     Minus,
     Undo2,
     Redo2,
-    Code2,
+    GripHorizontal,
 } from "lucide-static";
 
-@customElement("scms-rich-text-editor")
-export class RichTextEditor extends ScmsElement {
-    @property({ type: String })
-    content = "";
-
+@customElement("scms-formatting-toolbar")
+export class FormattingToolbar extends ScmsElement {
     @property({ type: Boolean })
     compact = false;
 
     @state()
-    private sourceMode = false;
-
-    @state()
-    private sourceContent = "";
-
-    @state()
     private activeFormats: Set<string> = new Set();
 
-    private editor: Editor | null = null;
+    @state()
+    private posX = -1;
+
+    @state()
+    private posY = 12;
+
+    /** The Tiptap editor for the currently active element. */
+    editor: Editor | null = null;
+
+    /** The element currently being edited. */
+    targetElement: HTMLElement | null = null;
+
+    /** The HTML at the time the current editor was created, for change detection. */
     private initialHTML = "";
+
+    /** All active editors, keyed by element. Preserved across blur/focus for undo history. */
+    editors: Map<HTMLElement, { editor: Editor; initialHTML: string }> = new Map();
+
+    private dragStartX = 0;
+    private dragStartY = 0;
+    private dragStartPosX = 0;
+    private dragStartPosY = 0;
+    /**
+     * Callback fired on each content update. Set by the controller
+     * to sync content changes back to the content manager.
+     */
+    onContentUpdate: (() => void) | null = null;
 
     static styles = [
         ...ScmsElement.styles,
         css`
-            .editor-wrapper {
-                border: 1px solid #d1d5db;
-                border-radius: 0.375rem;
-                overflow: hidden;
-            }
-
-            .editor-wrapper:focus-within {
-                border-color: #9ca3af;
-                box-shadow: 0 0 0 1px #9ca3af;
-            }
-
-            .ProseMirror {
-                outline: none;
-                padding: 0.75rem;
-                font-size: 14px;
-                line-height: 1.6;
-            }
-
-            :host([compact]) .ProseMirror {
-                min-height: 80px;
-                max-height: 200px;
-                overflow-y: auto;
-            }
-
-            :host(:not([compact])) .ProseMirror {
-                min-height: 200px;
-                max-height: 50vh;
-                overflow-y: auto;
-            }
-
-            .ProseMirror p {
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror h1 {
-                font-size: 1.5em;
-                font-weight: 700;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror h2 {
-                font-size: 1.25em;
-                font-weight: 600;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror h3 {
-                font-size: 1.1em;
-                font-weight: 600;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror ul {
-                list-style: disc;
-                padding-left: 1.5em;
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror ol {
-                list-style: decimal;
-                padding-left: 1.5em;
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror li {
-                margin: 0.1em 0;
-            }
-
-            .ProseMirror blockquote {
-                border-left: 3px solid #d1d5db;
-                padding-left: 1em;
-                color: #6b7280;
-                margin: 0.5em 0;
-            }
-
-            .ProseMirror a {
-                color: #2563eb;
-                text-decoration: underline;
-            }
-
-            .ProseMirror code {
-                background: #f3f4f6;
-                padding: 0.15em 0.35em;
-                border-radius: 0.25em;
-                font-size: 0.875em;
-                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-                    monospace;
-            }
-
-            .ProseMirror hr {
-                border: none;
-                border-top: 1px solid #d1d5db;
-                margin: 1em 0;
-            }
-
-            .ProseMirror p.is-editor-empty:first-child::before {
-                content: attr(data-placeholder);
-                color: #9ca3af;
+            :host {
+                position: fixed;
+                z-index: 10000;
+                display: block;
                 pointer-events: none;
-                float: left;
-                height: 0;
             }
 
-            .source-textarea {
-                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-                    monospace;
-                font-size: 13px;
-                line-height: 1.5;
-                tab-size: 2;
-                padding: 0.75rem;
-                width: 100%;
-                border: none;
-                outline: none;
-                resize: none;
+            .toolbar-container {
+                pointer-events: auto;
+                display: inline-flex;
+                align-items: center;
+                gap: 2px;
+                padding: 4px 8px;
+                background: white;
+                border: 1px solid #e5e7eb;
+                border-radius: 8px;
+                box-shadow:
+                    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+                    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+                flex-wrap: wrap;
             }
 
-            :host([compact]) .source-textarea {
-                min-height: 80px;
-                max-height: 200px;
+            .drag-handle {
+                cursor: grab;
+                padding: 4px 2px;
+                color: #9ca3af;
+                display: flex;
+                align-items: center;
+                user-select: none;
+                -webkit-user-select: none;
             }
 
-            :host(:not([compact])) .source-textarea {
-                min-height: 200px;
-                max-height: 50vh;
+            .drag-handle:active {
+                cursor: grabbing;
             }
 
             button {
@@ -188,80 +125,154 @@ export class RichTextEditor extends ScmsElement {
         `,
     ];
 
-    firstUpdated() {
-        const editorElement = this.shadowRoot!.querySelector("#editor") as HTMLElement;
-        if (!editorElement) return;
+    /**
+     * Attach Tiptap to a page element and show the toolbar.
+     * Reuses existing editor for the same element (preserves undo history).
+     * Creates a new editor for new elements without destroying others.
+     */
+    attach(element: HTMLElement, compact: boolean): void {
+        this.compact = compact;
+        this.targetElement = element;
 
+        // Reuse existing editor for this element
+        const existing = this.editors.get(element);
+        if (existing) {
+            this.editor = existing.editor;
+            this.initialHTML = existing.initialHTML;
+            this.editor.commands.focus();
+            this.updateActiveFormats();
+            this.style.display = "block";
+            return;
+        }
+
+        // Create new editor
         this.editor = new Editor({
-            element: editorElement,
+            element: { mount: element },
+            content: element.innerHTML,
             extensions: [
                 StarterKit.configure({
-                    heading: this.compact ? false : { levels: [1, 2, 3] },
-                    bulletList: this.compact ? false : undefined,
-                    orderedList: this.compact ? false : undefined,
-                    blockquote: this.compact ? false : undefined,
-                    horizontalRule: this.compact ? false : undefined,
-                    strike: this.compact ? false : undefined,
-                    code: this.compact ? false : undefined,
+                    document: false,
+                    listItem: false,
+                    blockquote: false,
+                    trailingNode: false,
+                    link: false,
+                    heading: { levels: [1, 2, 3] },
                 }),
+                FlexDocument,
+                SpanParagraph,
+                ListParagraph,
+                FlexListItem,
+                FlexBlockquote,
                 Link.configure({
                     openOnClick: false,
-                    HTMLAttributes: {
-                        rel: null,
-                        target: null,
-                    },
+                    HTMLAttributes: { rel: null, target: null },
                 }),
-                Underline,
             ],
-            content: this.content,
-            onTransaction: () => {
+            onUpdate: () => {
                 this.updateActiveFormats();
-                this.dispatchEvent(
-                    new CustomEvent("content-change", {
-                        detail: { content: this.editor!.getHTML() },
-                        bubbles: true,
-                        composed: true,
-                    }),
-                );
+                this.onContentUpdate?.();
+            },
+            onSelectionUpdate: () => {
+                this.updateActiveFormats();
             },
         });
 
         this.initialHTML = this.editor.getHTML();
+        this.editors.set(element, { editor: this.editor, initialHTML: this.initialHTML });
+
+        // Center horizontally on first show
+        if (this.posX === -1) {
+            requestAnimationFrame(() => {
+                const toolbar = this.shadowRoot?.querySelector(
+                    ".toolbar-container",
+                ) as HTMLElement | null;
+                if (toolbar) {
+                    this.posX = Math.max(
+                        12,
+                        (window.innerWidth - toolbar.offsetWidth) / 2,
+                    );
+                }
+            });
+        }
+
         this.updateActiveFormats();
+        this.style.display = "block";
+    }
+
+    /**
+     * Whether the current editor's content has changed from when it was loaded.
+     */
+    hasChanges(): boolean {
+        if (!this.editor) return false;
+        return this.editor.getHTML() !== this.initialHTML;
+    }
+
+    /**
+     * Check if a specific element's editor has changes.
+     */
+    hasChangesFor(element: HTMLElement): boolean {
+        const entry = this.editors.get(element);
+        if (!entry) return false;
+        return entry.editor.getHTML() !== entry.initialHTML;
+    }
+
+    /**
+     * Destroy the editor for a specific element and restore its HTML.
+     */
+    detachElement(element: HTMLElement): void {
+        const entry = this.editors.get(element);
+        if (!entry) return;
+
+        const finalHTML = entry.editor.getHTML();
+        entry.editor.destroy();
+        this.editors.delete(element);
+        element.innerHTML = finalHTML;
+
+        // If this was the active element, clear current state
+        if (this.targetElement === element) {
+            this.editor = null;
+            this.targetElement = null;
+            this.activeFormats = new Set();
+            this.style.display = "none";
+        }
+    }
+
+    /**
+     * Destroy all editors and clean up.
+     */
+    detach(): void {
+        for (const [element, entry] of this.editors) {
+            const finalHTML = entry.editor.getHTML();
+            entry.editor.destroy();
+            element.innerHTML = finalHTML;
+        }
+        this.editors.clear();
+        this.editor = null;
+        this.targetElement = null;
+        this.activeFormats = new Set();
+        this.style.display = "none";
+    }
+
+    /**
+     * Get the current content as HTML.
+     */
+    getHTML(): string {
+        return this.editor?.getHTML() || "";
+    }
+
+    /**
+     * Programmatically set the editor content.
+     */
+    setContent(htmlContent: string): void {
+        if (this.editor) {
+            this.editor.commands.setContent(htmlContent, { emitUpdate: true });
+        }
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
-        this.editor?.destroy();
-        this.editor = null;
-    }
+        this.detach();
 
-    updated(changedProperties: Map<string, unknown>) {
-        if (changedProperties.has("content") && this.editor) {
-            const currentHTML = this.editor.getHTML();
-            if (currentHTML !== this.content) {
-                this.editor.commands.setContent(this.content, { emitUpdate: false });
-            }
-        }
-    }
-
-    /**
-     * Get the current editor content as HTML
-     */
-    getHTML(): string {
-        if (this.sourceMode) {
-            return this.sourceContent;
-        }
-        return this.editor?.getHTML() || this.content;
-    }
-
-    /**
-     * Whether the editor content has changed from what was initially loaded.
-     * Compares against Tiptap-normalized HTML to avoid false positives from
-     * normalization (e.g. "Hello" → "<p>Hello</p>").
-     */
-    hasChanges(): boolean {
-        return this.getHTML() !== this.initialHTML;
     }
 
     private updateActiveFormats() {
@@ -284,33 +295,33 @@ export class RichTextEditor extends ScmsElement {
         this.activeFormats = formats;
     }
 
-    private toggleSourceMode() {
-        if (this.sourceMode) {
-            // Switching back to rich text: apply source content to editor
-            if (this.editor) {
-                this.editor.commands.setContent(this.sourceContent, { emitUpdate: false });
-            }
-            this.sourceMode = false;
-        } else {
-            // Switching to source: capture editor HTML
-            this.sourceContent = this.editor?.getHTML() || this.content;
-            this.sourceMode = true;
-        }
+    // --- Drag handling ---
+
+    private handleDragStart(e: PointerEvent) {
+        this.dragStartX = e.clientX;
+        this.dragStartY = e.clientY;
+        this.dragStartPosX = this.posX;
+        this.dragStartPosY = this.posY;
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - this.dragStartX;
+            const dy = ev.clientY - this.dragStartY;
+            this.posX = Math.max(0, this.dragStartPosX + dx);
+            this.posY = Math.max(0, this.dragStartPosY + dy);
+        };
+
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
     }
 
-    private handleSourceInput(e: Event) {
-        const textarea = e.target as HTMLTextAreaElement;
-        this.sourceContent = textarea.value;
-        this.dispatchEvent(
-            new CustomEvent("content-change", {
-                detail: { content: this.sourceContent },
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    }
+    // --- Command execution ---
 
-    private exec(command: string, options?: Record<string, unknown>) {
+    private exec(command: string) {
         if (!this.editor) return;
         const chain = this.editor.chain().focus();
 
@@ -352,14 +363,19 @@ export class RichTextEditor extends ScmsElement {
                 chain.setHorizontalRule().run();
                 break;
             case "link": {
-                if (this.editor.isActive("link")) {
+                const currentHref = this.editor.getAttributes("link").href || "";
+                const message = currentHref
+                    ? "Edit URL (clear to remove link):"
+                    : "Enter URL:";
+                const href = prompt(message, currentHref);
+                if (href === null) {
+                    // User cancelled — do nothing
+                } else if (href === "") {
+                    // Empty input — remove link
                     chain.unsetLink().run();
                 } else {
-                    const url = options?.href as string | undefined;
-                    const href = url || prompt("Enter URL:");
-                    if (href) {
-                        chain.setLink({ href }).run();
-                    }
+                    // Set or update link
+                    chain.setLink({ href }).run();
                 }
                 break;
             }
@@ -372,12 +388,9 @@ export class RichTextEditor extends ScmsElement {
         }
     }
 
-    private renderToolbarButton(
-        command: string,
-        icon: string,
-        title: string,
-        options?: Record<string, unknown>,
-    ) {
+    // --- Rendering ---
+
+    private renderButton(command: string, icon: string, title: string) {
         const isActive = this.activeFormats.has(command);
         return html`
             <button
@@ -386,7 +399,8 @@ export class RichTextEditor extends ScmsElement {
                     ? "bg-gray-200 text-gray-900"
                     : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
                 title=${title}
-                @click=${() => this.exec(command, options)}
+                @mousedown=${(e: Event) => e.preventDefault()}
+                @click=${() => this.exec(command)}
             >
                 <span class="[&>svg]:w-4 [&>svg]:h-4 flex items-center justify-center">
                     ${unsafeSVG(icon)}
@@ -399,90 +413,50 @@ export class RichTextEditor extends ScmsElement {
         return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
     }
 
-    private renderToolbar() {
-        if (this.compact) {
-            return html`
-                <div
-                    class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
-                >
-                    <div class="flex items-center gap-0.5">
-                        ${this.renderToolbarButton("bold", Bold, "Bold")}
-                        ${this.renderToolbarButton("italic", Italic, "Italic")}
-                        ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
-                        ${this.renderSeparator()}
-                        ${this.renderToolbarButton("link", LinkIcon, "Link")}
-                    </div>
-                    <div class="flex-1"></div>
-                    ${this.renderSourceToggle()}
-                </div>
-            `;
-        }
+    render() {
+        if (!this.editor) return nothing;
+
+        const left = this.posX === -1 ? "50%" : `${this.posX}px`;
+        const transform = this.posX === -1 ? "translateX(-50%)" : "none";
 
         return html`
             <div
-                class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+                class="toolbar-container"
+                style="position:fixed; top:${this.posY}px; left:${left}; transform:${transform};"
             >
-                <div class="flex items-center gap-0.5">
-                    ${this.renderToolbarButton("bold", Bold, "Bold")}
-                    ${this.renderToolbarButton("italic", Italic, "Italic")}
-                    ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
-                    ${this.renderToolbarButton("strike", Strikethrough, "Strikethrough")}
-                    ${this.renderToolbarButton("code", Code, "Inline Code")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("h1", Heading1, "Heading 1")}
-                    ${this.renderToolbarButton("h2", Heading2, "Heading 2")}
-                    ${this.renderToolbarButton("h3", Heading3, "Heading 3")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("bulletList", List, "Bullet List")}
-                    ${this.renderToolbarButton("orderedList", ListOrdered, "Ordered List")}
-                    ${this.renderToolbarButton("blockquote", Quote, "Blockquote")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("link", LinkIcon, "Link")}
-                    ${this.renderToolbarButton("horizontalRule", Minus, "Horizontal Rule")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("undo", Undo2, "Undo")}
-                    ${this.renderToolbarButton("redo", Redo2, "Redo")}
+                <div
+                    class="drag-handle"
+                    @pointerdown=${this.handleDragStart}
+                    title="Drag to reposition"
+                >
+                    <span class="[&>svg]:w-4 [&>svg]:h-4">
+                        ${unsafeSVG(GripHorizontal)}
+                    </span>
                 </div>
-                <div class="flex-1"></div>
-                ${this.renderSourceToggle()}
-            </div>
-        `;
-    }
-
-    private renderSourceToggle() {
-        return html`
-            <button
-                type="button"
-                class="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${this
-                    .sourceMode
-                    ? "bg-gray-200 text-gray-900"
-                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
-                title=${this.sourceMode ? "Switch to rich text" : "View HTML source"}
-                @click=${this.toggleSourceMode}
-            >
-                <span class="[&>svg]:w-3.5 [&>svg]:h-3.5 flex items-center">
-                    ${unsafeSVG(Code2)}
-                </span>
-                ${this.sourceMode ? "Rich Text" : "Source"}
-            </button>
-        `;
-    }
-
-    render() {
-        return html`
-            <div class="editor-wrapper">
-                ${this.renderToolbar()}
-                <div id="editor" style=${this.sourceMode ? "display:none" : nothing}></div>
-                ${this.sourceMode
-                    ? html`
-                          <textarea
-                              class="source-textarea"
-                              .value=${this.sourceContent}
-                              @input=${this.handleSourceInput}
-                              spellcheck="false"
-                          ></textarea>
-                      `
-                    : nothing}
+                ${this.renderSeparator()}
+                ${this.renderButton("bold", Bold, "Bold")}
+                ${this.renderButton("italic", Italic, "Italic")}
+                ${this.renderButton("underline", UnderlineIcon, "Underline")}
+                ${this.renderButton("strike", Strikethrough, "Strikethrough")}
+                ${this.renderButton("code", Code, "Inline Code")}
+                ${this.renderSeparator()}
+                ${this.renderButton("h1", Heading1, "Heading 1")}
+                ${this.renderButton("h2", Heading2, "Heading 2")}
+                ${this.renderButton("h3", Heading3, "Heading 3")}
+                ${this.compact
+                    ? nothing
+                    : html`
+                          ${this.renderSeparator()}
+                          ${this.renderButton("bulletList", List, "Bullet List")}
+                          ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
+                          ${this.renderButton("blockquote", Quote, "Blockquote")}
+                      `}
+                ${this.compact ? nothing : this.renderSeparator()}
+                ${this.compact ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                ${this.compact ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.renderSeparator()}
+                ${this.renderButton("undo", Undo2, "Undo")}
+                ${this.renderButton("redo", Redo2, "Redo")}
             </div>
         `;
     }
@@ -490,6 +464,6 @@ export class RichTextEditor extends ScmsElement {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "scms-rich-text-editor": RichTextEditor;
+        "scms-formatting-toolbar": FormattingToolbar;
     }
 }

--- a/src/components/seo-modal.ts
+++ b/src/components/seo-modal.ts
@@ -309,14 +309,7 @@ export class SeoModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">SEO Attributes</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">SEO Attributes</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -6,7 +6,7 @@
  * - Mobile: collapses secondary actions into expandable drawer
  *
  * Primary actions (always visible): Save, Reset
- * Secondary actions (collapsible on mobile): Mode toggle, Edit Content, Sign Out
+ * Secondary actions (collapsible on mobile): Mode toggle, View Source, Sign Out
  */
 
 import { html, css, nothing } from "lit";
@@ -453,15 +453,15 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderEditHtmlButton() {
-        // Show only for html type (not for text, image, or link)
-        if (!this.activeElement || this.activeElementType !== "html") return nothing;
+        // Show for html and link types (not for text or image)
+        if (!this.activeElement || (this.activeElementType !== "html" && this.activeElementType !== "link")) return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
                 data-action="edit-html"
                 @click=${this.handleEditHtml}
             >
-                Edit Content
+                View Source
             </button>
         `;
     }
@@ -871,14 +871,14 @@ export class Toolbar extends ScmsElement {
                 `;
             }
 
-            if (this.activeElementType === "html") {
+            if (this.activeElementType === "html" || this.activeElementType === "link") {
                 return html`
                     <button
                         class="w-full px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-white transition-colors"
                         data-action="edit-html"
                         @click=${this.handleEditHtml}
                     >
-                        Edit Content
+                        View Source
                     </button>
                 `;
             }

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -445,7 +445,11 @@ export class Toolbar extends ScmsElement {
 
     private renderEditHtmlButton() {
         // Show for html and link types (not for text or image)
-        if (!this.activeElement || (this.activeElementType !== "html" && this.activeElementType !== "link")) return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "html" && this.activeElementType !== "link")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -6,7 +6,7 @@
  * - Mobile: collapses secondary actions into expandable drawer
  *
  * Primary actions (always visible): Save, Reset
- * Secondary actions (collapsible on mobile): Mode toggle, Edit HTML, Sign Out
+ * Secondary actions (collapsible on mobile): Mode toggle, Edit Content, Sign Out
  */
 
 import { html, css, nothing } from "lit";
@@ -461,7 +461,7 @@ export class Toolbar extends ScmsElement {
                 data-action="edit-html"
                 @click=${this.handleEditHtml}
             >
-                Edit HTML
+                Edit Content
             </button>
         `;
     }
@@ -878,7 +878,7 @@ export class Toolbar extends ScmsElement {
                         data-action="edit-html"
                         @click=${this.handleEditHtml}
                     >
-                        Edit HTML
+                        Edit Content
                     </button>
                 `;
             }

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -292,15 +292,6 @@ export class Toolbar extends ScmsElement {
         );
     }
 
-    private handleRedo() {
-        this.dispatchEvent(
-            new CustomEvent("redo", {
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    }
-
     private handleEditHtml() {
         this.dispatchEvent(
             new CustomEvent("edit-html", {

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -201,9 +201,7 @@ export const ParagraphSplitBlock = Extension.create({
                     deflt = getDefault();
 
                     let types =
-                        atEnd && deflt
-                            ? [{ type: deflt, attrs: $from.node().attrs }]
-                            : undefined;
+                        atEnd && deflt ? [{ type: deflt, attrs: $from.node().attrs }] : undefined;
 
                     let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types);
 

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -18,7 +18,9 @@
  *   - "<blockquote>text</bq>"   → <bq><span>text</span></bq>(no visual change)
  */
 
-import { Node, mergeAttributes } from "@tiptap/core";
+import { Extension, Node, mergeAttributes } from "@tiptap/core";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
+import { canSplit } from "@tiptap/pm/transform";
 
 /**
  * A block node that renders as <span> instead of <p>.
@@ -127,4 +129,129 @@ export const InlineDocument = Node.create({
     name: "doc",
     topNode: true,
     content: "inline*",
+});
+
+/**
+ * Overrides Tiptap's default splitBlock command so pressing Enter creates a
+ * <p> instead of a <span>. The schema lists spanParagraph first (so bare text
+ * loads without <p> wrapping), but ProseMirror's defaultBlockAt picks the
+ * first textblock from the parent's content match — which is spanParagraph.
+ *
+ * This extension replaces splitBlock with a copy of Tiptap's implementation
+ * that forces the new node type to "paragraph" when available, falling back
+ * to defaultBlockAt otherwise. List item splitting is unaffected (it has its
+ * own splitListItem command).
+ */
+export const ParagraphSplitBlock = Extension.create({
+    name: "paragraphSplitBlock",
+
+    addCommands() {
+        return {
+            splitBlock:
+                ({ keepMarks = true } = {}) =>
+                ({ tr, state, dispatch, editor }) => {
+                    const { selection, doc } = tr;
+                    const { $from, $to } = selection;
+
+                    const ensureMarks = () => {
+                        const marks =
+                            state.storedMarks ||
+                            (state.selection.$to.parentOffset && state.selection.$from.marks());
+                        if (marks) {
+                            const splittable = editor.extensionManager.splittableMarks;
+                            const filtered = marks.filter((m) => splittable?.includes(m.type.name));
+                            state.tr.ensureMarks(filtered);
+                        }
+                    };
+
+                    if (selection instanceof NodeSelection && selection.node.isBlock) {
+                        if (!$from.parentOffset || !canSplit(doc, $from.pos)) {
+                            return false;
+                        }
+                        if (dispatch) {
+                            if (keepMarks) ensureMarks();
+                            tr.split($from.pos).scrollIntoView();
+                        }
+                        return true;
+                    }
+
+                    if (!$from.parent.isBlock) return false;
+
+                    const atEnd = $to.parentOffset === $to.parent.content.size;
+
+                    // Pick the new block type: prefer "paragraph" if it's a valid
+                    // child of the parent at this position; otherwise fall back to
+                    // the parent's default textblock.
+                    let deflt = undefined as ReturnType<typeof getDefault>;
+                    function getDefault() {
+                        if ($from.depth === 0) return undefined;
+                        const match = $from.node(-1).contentMatchAt($from.indexAfter(-1));
+                        const paragraphType = editor.schema.nodes.paragraph;
+                        if (paragraphType && match.matchType(paragraphType)) {
+                            return paragraphType;
+                        }
+                        for (let i = 0; i < match.edgeCount; i += 1) {
+                            const { type } = match.edge(i);
+                            if (type.isTextblock && !type.hasRequiredAttrs()) {
+                                return type;
+                            }
+                        }
+                        return undefined;
+                    }
+                    deflt = getDefault();
+
+                    let types =
+                        atEnd && deflt
+                            ? [{ type: deflt, attrs: $from.node().attrs }]
+                            : undefined;
+
+                    let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types);
+
+                    if (
+                        !types &&
+                        !can &&
+                        canSplit(
+                            tr.doc,
+                            tr.mapping.map($from.pos),
+                            1,
+                            deflt ? [{ type: deflt }] : undefined,
+                        )
+                    ) {
+                        can = true;
+                        types = deflt ? [{ type: deflt, attrs: $from.node().attrs }] : undefined;
+                    }
+
+                    if (dispatch) {
+                        if (can) {
+                            if (selection instanceof TextSelection) {
+                                tr.deleteSelection();
+                            }
+                            tr.split(tr.mapping.map($from.pos), 1, types);
+
+                            if (
+                                deflt &&
+                                !atEnd &&
+                                !$from.parentOffset &&
+                                $from.parent.type !== deflt
+                            ) {
+                                const first = tr.mapping.map($from.before());
+                                const $first = tr.doc.resolve(first);
+                                if (
+                                    $from
+                                        .node(-1)
+                                        .canReplaceWith($first.index(), $first.index() + 1, deflt)
+                                ) {
+                                    tr.setNodeMarkup(tr.mapping.map($from.before()), deflt);
+                                }
+                            }
+                        }
+
+                        if (keepMarks) ensureMarks();
+                        tr.scrollIntoView();
+                    }
+
+                    return can;
+                },
+        };
+    },
 });

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -1,0 +1,130 @@
+/**
+ * Custom Tiptap Schema Extensions
+ *
+ * ProseMirror requires block nodes as children of Document, ListItem, and
+ * Blockquote. By default, bare inline content gets wrapped in a <p> tag,
+ * causing unwanted visual changes when the editor loads.
+ *
+ * These extensions solve this by defining a "spanParagraph" node that renders
+ * as <span> instead of <p>. It is placed first in content expressions so
+ * ProseMirror uses it as the default wrapper for bare text. The standard
+ * Paragraph node (renders <p>) is preserved for content that already has
+ * <p> tags — those parse into "paragraph" and round-trip cleanly.
+ *
+ * Result:
+ *   - "bare text"               → <span>bare text</span>    (no visual change)
+ *   - "<p>paragraph</p>"        → <p>paragraph</p>          (preserved)
+ *   - "<li>item</li>"           → <li><span>item</span></li>(no visual change)
+ *   - "<blockquote>text</bq>"   → <bq><span>text</span></bq>(no visual change)
+ */
+
+import { Node, mergeAttributes } from "@tiptap/core";
+
+/**
+ * A block node that renders as <span> instead of <p>.
+ * Used as the default wrapper for bare inline content, avoiding the visual
+ * impact of <p> tags (margins, line breaks). Never parsed from HTML — it
+ * is only created by ProseMirror when it needs to wrap bare text.
+ */
+export const SpanParagraph = Node.create({
+    name: "spanParagraph",
+
+    content: "inline*",
+
+    group: "block",
+
+    parseHTML() {
+        return [];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["span", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+/**
+ * Document node that prefers spanParagraph as the default wrapper.
+ * By listing spanParagraph first, ProseMirror uses it (instead of <p>)
+ * when bare text needs a block wrapper.
+ */
+export const FlexDocument = Node.create({
+    name: "doc",
+    topNode: true,
+    content: "(spanParagraph | block)+",
+});
+
+/**
+ * ListItem that uses a span-rendering wrapper for its required first
+ * block child, instead of paragraph which renders as <p>.
+ */
+export const ListParagraph = Node.create({
+    name: "listParagraph",
+
+    content: "inline*",
+
+    group: "block",
+
+    parseHTML() {
+        return [];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["span", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+export const FlexListItem = Node.create({
+    name: "listItem",
+
+    content: "(listParagraph | paragraph) block*",
+
+    defining: true,
+
+    parseHTML() {
+        return [{ tag: "li" }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["li", mergeAttributes(HTMLAttributes), 0];
+    },
+
+    addKeyboardShortcuts() {
+        return {
+            Enter: () => this.editor.commands.splitListItem(this.name),
+            Tab: () => this.editor.commands.sinkListItem(this.name),
+            "Shift-Tab": () => this.editor.commands.liftListItem(this.name),
+        };
+    },
+});
+
+/**
+ * Blockquote that prefers spanParagraph as the default wrapper,
+ * same pattern as FlexDocument.
+ */
+export const FlexBlockquote = Node.create({
+    name: "blockquote",
+
+    content: "(spanParagraph | block)+",
+
+    group: "block",
+
+    defining: true,
+
+    parseHTML() {
+        return [{ tag: "blockquote" }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["blockquote", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+/**
+ * Inline-only document node for compact/link editing mode.
+ * Content is purely inline — no block wrappers at all.
+ */
+export const InlineDocument = Node.create({
+    name: "doc",
+    topNode: true,
+    content: "inline*",
+});

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -72,6 +72,14 @@ export class ContentManager {
      * Returns JSON string with type field for all element types.
      * Includes attributes if any have been set.
      */
+    /**
+     * Get the HTML content of an element, using Tiptap's clean output if available.
+     */
+    private getElementHTML(element: HTMLElement): string {
+        const editor = this.state.tiptapEditors.get(element);
+        return editor ? editor.getHTML() : element.innerHTML;
+    }
+
     getElementContent(key: string, info: EditableElementInfo): string {
         const elementType = this.state.editableTypes.get(key) || "html";
         const attributes = this.state.elementAttributes.get(key);
@@ -88,7 +96,7 @@ export class ContentManager {
                 type: "link",
                 href: info.element.getAttribute("href") || "",
                 target: info.element.target,
-                value: info.element.innerHTML,
+                value: this.getElementHTML(info.element),
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
@@ -103,10 +111,22 @@ export class ContentManager {
             // html (default)
             const data: HtmlContentData = {
                 type: "html",
-                value: info.element.innerHTML,
+                value: this.getElementHTML(info.element),
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
+        }
+    }
+
+    /**
+     * Set the HTML content of an element, using Tiptap's API if available.
+     */
+    private setElementHTML(element: HTMLElement, htmlContent: string): void {
+        const editor = this.state.tiptapEditors.get(element);
+        if (editor) {
+            editor.commands.setContent(htmlContent, { emitUpdate: false });
+        } else {
+            element.innerHTML = htmlContent;
         }
     }
 
@@ -131,14 +151,14 @@ export class ContentManager {
             if (data.type === "text") {
                 info.element.textContent = (data as TextContentData).value;
             } else if (data.type === "html") {
-                info.element.innerHTML = (data as HtmlContentData).value;
+                this.setElementHTML(info.element, (data as HtmlContentData).value);
             } else if (data.type === "image" && info.element instanceof HTMLImageElement) {
                 info.element.src = (data as ImageContentData).src;
             } else if (data.type === "link" && info.element instanceof HTMLAnchorElement) {
                 const linkData = data as LinkContentData;
                 info.element.href = linkData.href;
                 info.element.target = linkData.target;
-                info.element.innerHTML = linkData.value;
+                this.setElementHTML(info.element, linkData.value);
             } else if (!data.type) {
                 // No type field in JSON - use element's declared type
                 if (elementType === "link" && info.element instanceof HTMLAnchorElement) {
@@ -146,7 +166,7 @@ export class ContentManager {
                     if (linkData.href !== undefined) {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
-                        info.element.innerHTML = linkData.value || "";
+                        this.setElementHTML(info.element, linkData.value || "");
                         return;
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
@@ -164,7 +184,7 @@ export class ContentManager {
                 } else if (elementType === "html") {
                     const htmlData = data as { value?: string };
                     if (htmlData.value !== undefined) {
-                        info.element.innerHTML = htmlData.value;
+                        this.setElementHTML(info.element, htmlData.value);
                         return;
                     }
                 }

--- a/src/lazy/draft-manager.ts
+++ b/src/lazy/draft-manager.ts
@@ -9,7 +9,7 @@
 
 import type { Logger } from "loganite";
 import type { EditorState } from "./state.js";
-import { EDITABLE_SELECTOR, IMAGE_PLACEHOLDER_DATA_URI, type EditableType } from "../types.js";
+import { EDITABLE_SELECTOR, type EditableType } from "../types.js";
 
 /**
  * Storage context for an element (used for building keys)

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -242,8 +242,10 @@ export class EditingManager {
                 info.element.dataset.scmsKeydownHandler = "true";
             }
 
-            // Make text and html elements contenteditable (not images or links)
-            if (elementType === "text" || elementType === "html") {
+            // Make text elements contenteditable. For html elements, tiptap
+            // owns contenteditable — managing it here causes conflicts with
+            // tiptap's view, leading to states where the cursor disappears.
+            if (elementType === "text") {
                 info.element.setAttribute("contenteditable", "true");
             }
 
@@ -309,12 +311,16 @@ export class EditingManager {
         // Notify controller before cleanup (for formatting toolbar detach, etc.)
         this.helpers.onStopEditing(this.state.editingKey);
 
+        const elementType = this.state.editableTypes.get(this.state.editingKey) || "html";
         const infos = this.state.editableElements.get(this.state.editingKey);
         if (infos) {
             for (const info of infos) {
                 info.element.classList.remove("streamlined-editing");
                 info.element.classList.remove("streamlined-editing-sibling");
-                info.element.setAttribute("contenteditable", "false");
+                // Only manage contenteditable for text elements; tiptap owns it for html.
+                if (elementType === "text") {
+                    info.element.setAttribute("contenteditable", "false");
+                }
             }
         }
 

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -21,6 +21,8 @@ export interface EditingManagerHelpers {
     updateToolbarTemplateContext: () => void;
     getElementToKeyMap: () => WeakMap<HTMLElement, string>;
     scrollToElement: (element: HTMLElement, delay?: number) => void;
+    onStartEditing: (key: string, element: HTMLElement, elementType: string) => void;
+    onStopEditing: (key: string) => void;
 }
 
 export class EditingManager {
@@ -216,7 +218,7 @@ export class EditingManager {
                 info.element.classList.add("streamlined-editing-sibling");
             }
 
-            // Add input listener to all elements for change tracking and synchronization
+            // Add input listener for text and html elements for change tracking
             if (
                 (elementType === "text" || elementType === "html") &&
                 !info.element.dataset.scmsInputHandler
@@ -241,7 +243,6 @@ export class EditingManager {
             }
 
             // Make text and html elements contenteditable (not images or links)
-            // Only the primary element is focused, but all are editable for consistency
             if (elementType === "text" || elementType === "html") {
                 info.element.setAttribute("contenteditable", "true");
             }
@@ -254,6 +255,9 @@ export class EditingManager {
 
         // Focus the primary element (all types need focus for keyboard navigation)
         primaryInfo.element.focus();
+
+        // Notify controller that editing started (for formatting toolbar, etc.)
+        this.helpers.onStartEditing(key, primaryInfo.element, elementType);
 
         // On mobile, scroll the element into view after keyboard opens
         if (window.innerWidth < 640) {
@@ -301,6 +305,9 @@ export class EditingManager {
         }
 
         this.log.trace("Stopping edit");
+
+        // Notify controller before cleanup (for formatting toolbar detach, etc.)
+        this.helpers.onStopEditing(this.state.editingKey);
 
         const infos = this.state.editableElements.get(this.state.editingKey);
         if (infos) {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -797,12 +797,10 @@ class EditorController {
                         now - this.state.lastTapTime < this.doubleTapDelay;
 
                     if (isDoubleTap && isMobile) {
-                        // Mobile double-tap: open media manager for images, navigate for links
-                        // (Desktop uses native dblclick event instead)
+                        // Mobile double-tap: open media manager for images
+                        // (Link "go to" is handled by the formatting toolbar)
                         if (elementType === "image") {
                             this.modalManager.handleChangeImage();
-                        } else if (elementType === "link") {
-                            this.modalManager.handleGoToLink();
                         }
                         this.state.lastTapKey = null;
                         this.state.lastTapTime = 0;
@@ -845,17 +843,7 @@ class EditorController {
             element.dataset.scmsDblClickHandler = "true";
         }
 
-        // Double-click handler for links to navigate (desktop)
-        if (elementType === "link" && !element.dataset.scmsDblClickHandler) {
-            element.addEventListener("dblclick", (e) => {
-                if (this.state.editingEnabled) {
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                    this.modalManager.handleGoToLink();
-                }
-            });
-            element.dataset.scmsDblClickHandler = "true";
-        }
+        // Link "go to" is handled by the formatting toolbar's Go to Link button
     }
 
     /**
@@ -1094,7 +1082,7 @@ class EditorController {
     ): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
-            const compact = elementType === "link";
+            const linkMode = elementType === "link";
 
             // Wire up content sync for this element
             toolbar.onContentUpdate = () => {
@@ -1106,7 +1094,7 @@ class EditorController {
             };
 
             // Attach (reuses existing editor if available, creates new otherwise)
-            toolbar.attach(element, compact);
+            toolbar.attach(element, linkMode);
 
             // Register editor in state so content manager can use Tiptap's API.
             if (toolbar.editor) {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -63,6 +63,7 @@ function getConfigFromScriptTag(): ViewerConfig | null {
 // Import Lit components to register them
 import "../components/toolbar.js";
 import "../components/sign-in-link.js";
+import "../components/rich-text-editor.js";
 import "../components/html-editor-modal.js";
 import "../components/link-editor-modal.js";
 import "../components/seo-modal.js";

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1060,9 +1060,7 @@ class EditorController {
      */
     private ensureFormattingToolbar(): FormattingToolbar {
         if (!this.state.formattingToolbar) {
-            const toolbar = document.createElement(
-                "scms-formatting-toolbar",
-            ) as FormattingToolbar;
+            const toolbar = document.createElement("scms-formatting-toolbar") as FormattingToolbar;
             toolbar.style.display = "none";
             document.body.appendChild(toolbar);
             this.state.formattingToolbar = toolbar;
@@ -1075,11 +1073,7 @@ class EditorController {
      * Attaches or reuses a Tiptap editor for html/link element types.
      * Editors are preserved across blur/focus to maintain undo history.
      */
-    private handleEditingStarted(
-        key: string,
-        element: HTMLElement,
-        elementType: string,
-    ): void {
+    private handleEditingStarted(key: string, element: HTMLElement, elementType: string): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
             const linkMode = elementType === "link";

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -9,6 +9,7 @@
  * - Editing functionality
  */
 
+import { markRaw } from "@vue/reactivity";
 import { Logger } from "loganite";
 import { KeyStorage, type EditorMode } from "../key-storage.js";
 import { PopupManager, type MediaFile } from "../popup-manager.js";
@@ -74,6 +75,7 @@ import "../components/help-panel.js";
 import "../components/content-viewer-badge.js";
 import "../components/content-viewer-panel.js";
 import type { Toolbar } from "../components/toolbar.js";
+import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HelpPanel } from "../components/help-panel.js";
 import { createEditorState, type EditorState, type EditableElementInfo } from "./state.js";
 import { DraftManager } from "./draft-manager.js";
@@ -226,6 +228,9 @@ class EditorController {
             updateToolbarTemplateContext: () => this.templateManager.updateToolbarTemplateContext(),
             getElementToKeyMap: () => this.elementToKey,
             scrollToElement: this.scrollToElement.bind(this),
+            onStartEditing: (key, element, elementType) =>
+                this.handleEditingStarted(key, element, elementType),
+            onStopEditing: (key) => this.handleEditingStopped(key),
         });
 
         // Initialize modal manager
@@ -1053,6 +1058,101 @@ class EditorController {
             this.spacerElement.remove();
             this.spacerElement = null;
         }
+        // Also remove formatting toolbar
+        this.detachFormattingToolbar();
+        if (this.state.formattingToolbar) {
+            this.state.formattingToolbar.remove();
+            this.state.formattingToolbar = null;
+        }
+    }
+
+    /**
+     * Ensure the formatting toolbar component exists in the DOM.
+     * Created once and reused across editing sessions.
+     */
+    private ensureFormattingToolbar(): FormattingToolbar {
+        if (!this.state.formattingToolbar) {
+            const toolbar = document.createElement(
+                "scms-formatting-toolbar",
+            ) as FormattingToolbar;
+            toolbar.style.display = "none";
+            document.body.appendChild(toolbar);
+            this.state.formattingToolbar = toolbar;
+        }
+        return this.state.formattingToolbar;
+    }
+
+    /**
+     * Called when editing starts on an element.
+     * Attaches or reuses a Tiptap editor for html/link element types.
+     * Editors are preserved across blur/focus to maintain undo history.
+     */
+    private handleEditingStarted(
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+    ): void {
+        if (elementType === "html" || elementType === "link") {
+            const toolbar = this.ensureFormattingToolbar();
+            const compact = elementType === "link";
+
+            // Wire up content sync for this element
+            toolbar.onContentUpdate = () => {
+                const infos = this.state.editableElements.get(key);
+                if (!infos || infos.length === 0) return;
+                const sourceInfo = infos.find((i) => i.element === element) || infos[0];
+                this.contentManager.updateContentFromElement(key, sourceInfo.element);
+                this.saveManager.updateToolbarHasChanges();
+            };
+
+            // Attach (reuses existing editor if available, creates new otherwise)
+            toolbar.attach(element, compact);
+
+            // Register editor in state so content manager can use Tiptap's API.
+            if (toolbar.editor) {
+                this.state.tiptapEditors.set(element, markRaw(toolbar.editor));
+            }
+        }
+    }
+
+    /**
+     * Called when editing stops on an element.
+     * Hides the formatting toolbar but keeps the editor alive for undo history.
+     */
+    private handleEditingStopped(_key: string): void {
+        if (!this.state.formattingToolbar) return;
+        this.state.formattingToolbar.style.display = "none";
+    }
+
+    /**
+     * Destroy all formatting toolbar editors, sync changed content, and clean up.
+     * Called when editing is disabled (sign out, mode change).
+     */
+    private detachFormattingToolbar(): void {
+        if (!this.state.formattingToolbar) return;
+
+        const toolbar = this.state.formattingToolbar;
+
+        // Sync and unregister each editor that has changes
+        for (const [element] of toolbar.editors) {
+            this.state.tiptapEditors.delete(element);
+
+            // Find the key for this element
+            if (toolbar.hasChangesFor(element)) {
+                for (const [k, infos] of this.state.editableElements) {
+                    if (infos.some((i) => i.element === element)) {
+                        toolbar.detachElement(element);
+                        this.contentManager.updateContentFromElement(k, infos[0].element);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Destroy any remaining editors
+        toolbar.detach();
+        toolbar.onContentUpdate = null;
+        this.saveManager.updateToolbarHasChanges();
     }
 
     /**

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -197,7 +197,10 @@ export class ModalManager {
         if (storedContent) {
             try {
                 const data = JSON.parse(storedContent) as { type?: string; value?: string };
-                if ((data.type === "html" || data.type === "text" || data.type === "link") && data.value !== undefined) {
+                if (
+                    (data.type === "html" || data.type === "text" || data.type === "link") &&
+                    data.value !== undefined
+                ) {
                     htmlValue = data.value;
                 }
             } catch {

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -197,7 +197,7 @@ export class ModalManager {
         if (storedContent) {
             try {
                 const data = JSON.parse(storedContent) as { type?: string; value?: string };
-                if ((data.type === "html" || data.type === "text") && data.value !== undefined) {
+                if ((data.type === "html" || data.type === "text" || data.type === "link") && data.value !== undefined) {
                     htmlValue = data.value;
                 }
             } catch {
@@ -216,14 +216,30 @@ export class ModalManager {
         });
 
         modal.addEventListener("apply", ((e: CustomEvent<{ content: string }>) => {
-            // Build content and update via setContent
+            const elementType = this.state.editableTypes?.get(key) || "html";
             const attributes = this.state.elementAttributes.get(key);
-            const data: HtmlContentData = {
-                type: "html",
-                value: e.detail.content,
-                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
-            };
-            this.contentManager.setContent(key, JSON.stringify(data));
+
+            let content: string;
+            if (elementType === "link" && primaryInfo.element instanceof HTMLAnchorElement) {
+                // For links, update the value (innerHTML) while preserving href/target
+                const data: LinkContentData = {
+                    type: "link",
+                    href: primaryInfo.element.getAttribute("href") || "",
+                    target: primaryInfo.element.target,
+                    value: e.detail.content,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            } else {
+                const data: HtmlContentData = {
+                    type: "html",
+                    value: e.detail.content,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            }
+
+            this.contentManager.setContent(key, content);
             this.closeModal("htmlEditorModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("HTML applied", {
@@ -270,10 +286,25 @@ export class ModalManager {
         // Create and show modal
         const modal = document.createElement("scms-link-editor-modal") as LinkEditorModal;
         modal.elementId = key;
+        // Read link value from stored content if available (avoids Tiptap normalization),
+        // fall back to DOM innerHTML
+        let linkValue = primaryAnchor.innerHTML;
+        const storedContent = this.state.currentContent.get(key);
+        if (storedContent) {
+            try {
+                const data = JSON.parse(storedContent) as { type?: string; value?: string };
+                if (data.type === "link" && data.value !== undefined) {
+                    linkValue = data.value;
+                }
+            } catch {
+                // Use DOM fallback
+            }
+        }
+
         modal.linkData = {
             href: primaryAnchor.getAttribute("href") || "",
             target: primaryAnchor.target,
-            value: primaryAnchor.innerHTML,
+            value: linkValue,
         };
 
         // Prevent clicks inside modal from deselecting the element

--- a/src/lazy/state.ts
+++ b/src/lazy/state.ts
@@ -11,7 +11,9 @@ import type Sortable from "sortablejs";
 import type { EditorMode } from "../key-storage.js";
 import type { AppPermissions, EditableType, ElementAttributes } from "../types.js";
 import type { Toolbar } from "../components/toolbar.js";
+import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HtmlEditorModal } from "../components/html-editor-modal.js";
+
 import type { LinkEditorModal } from "../components/link-editor-modal.js";
 import type { SeoModal } from "../components/seo-modal.js";
 import type { AccessibilityModal } from "../components/accessibility-modal.js";
@@ -43,6 +45,18 @@ export interface TemplateInfo {
 }
 
 /**
+ * Minimal interface for a rich text editor attached to an element.
+ * Used by the content manager to read/write content via Tiptap
+ * without importing the full Tiptap dependency.
+ */
+export interface RichTextEditorHandle {
+    getHTML(): string;
+    commands: {
+        setContent(content: string, options?: { emitUpdate?: boolean }): boolean;
+    };
+}
+
+/**
  * The reactive state shared across all managers
  */
 export interface EditorState {
@@ -70,6 +84,9 @@ export interface EditorState {
     editingKey: string | null;
     selectedInstance: HTMLElement | null;
 
+    // Rich text editors attached to elements (Tiptap)
+    tiptapEditors: Map<HTMLElement, RichTextEditorHandle>;
+
     // Templates
     templates: Map<string, TemplateInfo>;
     templateAddButtons: Map<string, HTMLButtonElement>;
@@ -77,6 +94,7 @@ export interface EditorState {
 
     // UI components
     toolbar: Toolbar | null;
+    formattingToolbar: FormattingToolbar | null;
     htmlEditorModal: HtmlEditorModal | null;
     linkEditorModal: LinkEditorModal | null;
     seoModal: SeoModal | null;
@@ -121,6 +139,9 @@ export function createEditorState(): EditorState {
         editingKey: null,
         selectedInstance: null,
 
+        // Rich text editors
+        tiptapEditors: new Map(),
+
         // Templates
         templates: new Map(),
         templateAddButtons: new Map(),
@@ -128,6 +149,7 @@ export function createEditorState(): EditorState {
 
         // UI components
         toolbar: null,
+        formattingToolbar: null,
         htmlEditorModal: null,
         linkEditorModal: null,
         seoModal: null,

--- a/src/lazy/tours/link-editing/desktop.ts
+++ b/src/lazy/tours/link-editing/desktop.ts
@@ -101,7 +101,6 @@ export function linkEditorStepDesktop(ctx: TourContext): TourStep {
     };
 }
 
-
 /**
  * Step pointing to Save button
  */

--- a/src/lazy/tours/link-editing/desktop.ts
+++ b/src/lazy/tours/link-editing/desktop.ts
@@ -101,21 +101,6 @@ export function linkEditorStepDesktop(ctx: TourContext): TourStep {
     };
 }
 
-/**
- * Step mentioning double-click behavior
- */
-export function goToLinkTipDesktop(ctx: TourContext): TourStep {
-    return {
-        element: () => ctx.findVisibleElement(".streamlined-editing[data-scms-link]"),
-        popover: {
-            title: "Quick Tip",
-            description: "You can double-click any link to go to its destination.",
-            side: "bottom",
-            align: "center",
-            showButtons: ["next", "close"],
-        },
-    };
-}
 
 /**
  * Step pointing to Save button

--- a/src/lazy/tours/link-editing/index.ts
+++ b/src/lazy/tours/link-editing/index.ts
@@ -7,7 +7,6 @@ import {
     selectLinkStepDesktop,
     editLinkStepDesktop,
     linkEditorStepDesktop,
-    goToLinkTipDesktop,
     saveStepDesktop,
 } from "./desktop";
 import {
@@ -16,7 +15,6 @@ import {
     openElementSectionStepMobile,
     editLinkStepMobile,
     linkEditorStepMobile,
-    goToLinkTipMobile,
     saveStepMobile,
 } from "./mobile";
 
@@ -54,7 +52,6 @@ export const linkEditingTour: TourDefinition = {
                 openElementSectionStepMobile(ctx),
                 editLinkStepMobile(ctx),
                 linkEditorStepMobile(ctx),
-                goToLinkTipMobile(ctx),
                 saveStepMobile(),
             ];
         }
@@ -63,7 +60,6 @@ export const linkEditingTour: TourDefinition = {
             selectLinkStepDesktop(ctx),
             editLinkStepDesktop(ctx),
             linkEditorStepDesktop(ctx),
-            goToLinkTipDesktop(ctx),
             saveStepDesktop(),
         ];
     },

--- a/src/lazy/tours/link-editing/mobile.ts
+++ b/src/lazy/tours/link-editing/mobile.ts
@@ -171,21 +171,6 @@ export function linkEditorStepMobile(ctx: TourContext): TourStep {
     };
 }
 
-/**
- * Step mentioning double-tap behavior
- */
-export function goToLinkTipMobile(ctx: TourContext): TourStep {
-    return {
-        element: () => ctx.findVisibleElement(".streamlined-editing[data-scms-link]"),
-        popover: {
-            title: "Quick Tip",
-            description: "You can double-tap any link to go to its destination.",
-            side: "bottom",
-            align: "center",
-            showButtons: ["next", "close"],
-        },
-    };
-}
 
 /**
  * Step pointing to Save button

--- a/src/lazy/tours/link-editing/mobile.ts
+++ b/src/lazy/tours/link-editing/mobile.ts
@@ -171,7 +171,6 @@ export function linkEditorStepMobile(ctx: TourContext): TourStep {
     };
 }
 
-
 /**
  * Step pointing to Save button
  */

--- a/tests/browser/desktop/drafts/persistence.test.ts
+++ b/tests/browser/desktop/drafts/persistence.test.ts
@@ -9,6 +9,7 @@ import { test, expect, beforeAll, afterEach } from "vitest";
 import {
     initializeSDK,
     waitForCondition,
+    setElementContent,
     setupTestHelpers,
     getController,
 } from "~/@browser-support/sdk-helpers.js";
@@ -55,8 +56,7 @@ async function editContent(element: HTMLElement, newContent: string): Promise<vo
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    element.innerHTML = newContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, newContent);
 
     await new Promise((r) => setTimeout(r, 100));
 }
@@ -77,8 +77,7 @@ test("draft is saved to localStorage when content changes", async () => {
     expect(Object.keys(draft.content).length).toBeGreaterThan(0);
 
     // Reset content
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("draft contains the edited content", async () => {
@@ -97,8 +96,7 @@ test("draft contains the edited content", async () => {
     expect(hasContent).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("draft is removed when content matches original", async () => {
@@ -111,9 +109,13 @@ test("draft is removed when content matches original", async () => {
     // Verify draft exists
     expect(localStorage.getItem(getDraftKey())).not.toBeNull();
 
-    // Revert to original
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    // Revert to original content
+    setElementContent(element, originalContent);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Stop editing so content syncs
+    document.body.click();
+    await waitForCondition(() => !element.classList.contains("streamlined-editing"));
     await new Promise((r) => setTimeout(r, 100));
 
     // Draft should be removed
@@ -136,9 +138,13 @@ test("toolbar hasChanges reflects unsaved state", async () => {
     // hasChanges should be true
     expect(toolbar!.hasChanges).toBe(true);
 
-    // Revert
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    // Revert to original
+    setElementContent(element, originalContent);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Stop editing so content syncs
+    document.body.click();
+    await waitForCondition(() => !element.classList.contains("streamlined-editing"));
     await new Promise((r) => setTimeout(r, 100));
 
     // hasChanges should be false
@@ -159,8 +165,7 @@ test("draft structure includes content and deleted arrays", async () => {
     expect(Array.isArray(draft.deleted)).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("multiple edits update the same draft", async () => {
@@ -172,8 +177,7 @@ test("multiple edits update the same draft", async () => {
     const firstDraft = localStorage.getItem(getDraftKey());
 
     // Second edit
-    element.innerHTML = "Second edit";
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, "Second edit");
     await new Promise((r) => setTimeout(r, 100));
 
     const secondDraft = localStorage.getItem(getDraftKey());
@@ -187,8 +191,7 @@ test("multiple edits update the same draft", async () => {
     expect(hasSecondEdit).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("invalid draft JSON in localStorage is handled gracefully", async () => {

--- a/tests/browser/desktop/editing-basic.test.ts
+++ b/tests/browser/desktop/editing-basic.test.ts
@@ -7,6 +7,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 
@@ -44,11 +45,8 @@ test("user can edit and save content", async () => {
         await waitForCondition(() => testTitle.classList.contains("streamlined-editing"));
     }
 
-    // Edit the content - use innerHTML for html-type elements
-    testTitle.innerHTML = "Test Edit - Browser Test";
-
-    // Trigger input event to notify SDK of changes
-    testTitle.dispatchEvent(new Event("input", { bubbles: true }));
+    // Edit the content
+    setElementContent(testTitle, "Test Edit - Browser Test");
 
     // Click save button (helper waits for Lit re-render)
     await clickToolbarButton("Save");

--- a/tests/browser/desktop/editing/text-elements.test.ts
+++ b/tests/browser/desktop/editing/text-elements.test.ts
@@ -138,7 +138,7 @@ test("toolbar shows Reset button for text elements", async () => {
     expect(holdButton).not.toBeNull();
 });
 
-test("text elements do not show Edit Content button", async () => {
+test("text elements do not show View Source button", async () => {
     const element = getTextElement();
     const toolbar = getToolbar();
 
@@ -150,12 +150,12 @@ test("text elements do not show Edit Content button", async () => {
 
     let hasEditHtmlButton = false;
     for (const btn of buttons) {
-        if (btn.textContent?.includes("Edit Content")) {
+        if (btn.textContent?.includes("View Source")) {
             hasEditHtmlButton = true;
             break;
         }
     }
 
-    // Text elements should NOT have Edit Content button
+    // Text elements should NOT have View Source button
     expect(hasEditHtmlButton).toBe(false);
 });

--- a/tests/browser/desktop/editing/text-elements.test.ts
+++ b/tests/browser/desktop/editing/text-elements.test.ts
@@ -138,7 +138,7 @@ test("toolbar shows Reset button for text elements", async () => {
     expect(holdButton).not.toBeNull();
 });
 
-test("text elements do not show Edit HTML button", async () => {
+test("text elements do not show Edit Content button", async () => {
     const element = getTextElement();
     const toolbar = getToolbar();
 
@@ -150,12 +150,12 @@ test("text elements do not show Edit HTML button", async () => {
 
     let hasEditHtmlButton = false;
     for (const btn of buttons) {
-        if (btn.textContent?.includes("Edit HTML")) {
+        if (btn.textContent?.includes("Edit Content")) {
             hasEditHtmlButton = true;
             break;
         }
     }
 
-    // Text elements should NOT have Edit HTML button
+    // Text elements should NOT have Edit Content button
     expect(hasEditHtmlButton).toBe(false);
 });

--- a/tests/browser/desktop/modals/accessibility-modal.test.ts
+++ b/tests/browser/desktop/modals/accessibility-modal.test.ts
@@ -282,14 +282,6 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openAccessibilityModalForLink();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});
-
 test("can toggle not-applicable fields section", async () => {
     const modal = await openAccessibilityModalForLink();
     const shadowRoot = modal.shadowRoot!;

--- a/tests/browser/desktop/modals/attributes-modal.test.ts
+++ b/tests/browser/desktop/modals/attributes-modal.test.ts
@@ -310,10 +310,3 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openAttributesModal();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});

--- a/tests/browser/desktop/modals/attributes-modal.test.ts
+++ b/tests/browser/desktop/modals/attributes-modal.test.ts
@@ -309,4 +309,3 @@ test("clicking backdrop cancels the modal", async () => {
     await waitForCondition(() => cancelCalled);
     expect(cancelCalled).toBe(true);
 });
-

--- a/tests/browser/desktop/modals/html-editor.test.ts
+++ b/tests/browser/desktop/modals/html-editor.test.ts
@@ -10,9 +10,11 @@ import {
     waitForCondition,
     waitForSelector,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 import type { HtmlEditorModal } from "~/src/components/html-editor-modal.js";
+import type { FormattingToolbar } from "~/src/components/rich-text-editor.js";
 
 beforeAll(async () => {
     setupTestHelpers();
@@ -42,7 +44,7 @@ async function openHtmlEditorModal(): Promise<HtmlEditorModal> {
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    const clicked = await clickToolbarButton("Edit HTML");
+    const clicked = await clickToolbarButton("View Source");
     expect(clicked).toBe(true);
 
     await waitForSelector("scms-html-editor-modal");
@@ -71,7 +73,7 @@ beforeEach(async () => {
     await resetState();
 });
 
-test("clicking Edit HTML opens the modal", async () => {
+test("clicking View Source opens the modal", async () => {
     const modal = await openHtmlEditorModal();
 
     expect(modal).not.toBeNull();
@@ -80,7 +82,6 @@ test("clicking Edit HTML opens the modal", async () => {
 
 test("modal shows current HTML content", async () => {
     const element = getHtmlElement();
-    const originalContent = element.innerHTML;
 
     const modal = await openHtmlEditorModal();
     const shadowRoot = modal.shadowRoot!;
@@ -88,7 +89,9 @@ test("modal shows current HTML content", async () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.value).toBe(originalContent);
+    // The modal shows the element's text content (may differ from innerHTML
+    // if Tiptap has normalized the DOM, e.g., wrapping bare text in <p>)
+    expect(textarea.value).toContain(element.textContent?.trim() || "");
 });
 
 test("can edit HTML content in textarea", async () => {
@@ -221,10 +224,68 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
+test("Tiptap to modal sync: inline edits appear in View Source", async () => {
+    const element = getHtmlElement();
+
+    // Click element to start editing (Tiptap attaches)
+    element.click();
+    await waitForCondition(() => element.classList.contains("streamlined-editing"));
+
+    // Edit content via Tiptap
+    setElementContent(element, "<p>Edited inline via Tiptap</p>");
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Open View Source modal
+    const clicked = await clickToolbarButton("View Source");
+    expect(clicked).toBe(true);
+    await waitForSelector("scms-html-editor-modal");
+
+    const modal = getHtmlEditorModal()!;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Modal textarea should show the Tiptap content
+    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.value).toContain("Edited inline via Tiptap");
+});
+
+test("modal to Tiptap sync: View Source edits update inline editor", async () => {
+    const element = getHtmlElement();
+
+    // Open modal (this clicks element first, attaching Tiptap)
     const modal = await openHtmlEditorModal();
     const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
 
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-title");
+    // Edit content in the modal textarea
+    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "<p>Edited in View Source modal</p>";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Click Apply
+    const buttons = shadowRoot.querySelectorAll("button");
+    let applyBtn: HTMLButtonElement | null = null;
+    for (const btn of buttons) {
+        if (btn.textContent?.trim() === "Apply") {
+            applyBtn = btn;
+            break;
+        }
+    }
+    expect(applyBtn).not.toBeNull();
+    applyBtn!.click();
+
+    // Wait for modal to close and content to sync
+    await waitForCondition(() => getHtmlEditorModal() === null);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The formatting toolbar (Tiptap) should reflect the modal's content
+    const toolbar = document.querySelector(
+        "scms-formatting-toolbar",
+    ) as FormattingToolbar | null;
+    if (toolbar?.editor) {
+        expect(toolbar.getHTML()).toContain("Edited in View Source modal");
+    }
+
+    // The element's visible text should also reflect the change
+    expect(element.textContent).toContain("Edited in View Source modal");
 });

--- a/tests/browser/desktop/modals/html-editor.test.ts
+++ b/tests/browser/desktop/modals/html-editor.test.ts
@@ -279,9 +279,7 @@ test("modal to Tiptap sync: View Source edits update inline editor", async () =>
     await new Promise((r) => setTimeout(r, 100));
 
     // The formatting toolbar (Tiptap) should reflect the modal's content
-    const toolbar = document.querySelector(
-        "scms-formatting-toolbar",
-    ) as FormattingToolbar | null;
+    const toolbar = document.querySelector("scms-formatting-toolbar") as FormattingToolbar | null;
     if (toolbar?.editor) {
         expect(toolbar.getHTML()).toContain("Edited in View Source modal");
     }

--- a/tests/browser/desktop/modals/link-editor.test.ts
+++ b/tests/browser/desktop/modals/link-editor.test.ts
@@ -118,9 +118,6 @@ test("link editor modal shows current link values", async () => {
     const urlInput = shadowRoot.querySelector('input[type="url"]') as HTMLInputElement;
     expect(urlInput.value).toMatch(/^https:\/\/example\.com\/?$/);
 
-    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.value).toBe("Default Link Text");
-
     const targetSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
     expect(targetSelect.value).toBe("");
 });
@@ -141,22 +138,6 @@ test("can edit link URL in the modal", async () => {
     // Verify the change is reflected
     await waitForCondition(() => urlInput.value === "https://newurl.com");
     expect(urlInput.value).toBe("https://newurl.com");
-});
-
-test("can edit link text in the modal", async () => {
-    const modal = await openLinkEditor();
-    const shadowRoot = modal.shadowRoot!;
-
-    await new Promise((r) => setTimeout(r, 100));
-
-    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-
-    // Change the link text
-    textarea.value = "New Link Text";
-    textarea.dispatchEvent(new Event("input", { bubbles: true }));
-
-    await waitForCondition(() => textarea.value === "New Link Text");
-    expect(textarea.value).toBe("New Link Text");
 });
 
 test("can change link target in the modal", async () => {
@@ -301,11 +282,3 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openLinkEditor();
-    const shadowRoot = modal.shadowRoot!;
-
-    // Find the element ID display in the header
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});

--- a/tests/browser/desktop/modals/link-editor.test.ts
+++ b/tests/browser/desktop/modals/link-editor.test.ts
@@ -281,4 +281,3 @@ test("clicking backdrop cancels the modal", async () => {
     await waitForCondition(() => cancelCalled);
     expect(cancelCalled).toBe(true);
 });
-

--- a/tests/browser/desktop/modals/seo-modal.test.ts
+++ b/tests/browser/desktop/modals/seo-modal.test.ts
@@ -317,14 +317,6 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openSeoModalForLink();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});
-
 test("can toggle not-applicable fields section", async () => {
     const modal = await openSeoModalForLink();
     const shadowRoot = modal.shadowRoot!;

--- a/tests/browser/desktop/save/basic.test.ts
+++ b/tests/browser/desktop/save/basic.test.ts
@@ -10,6 +10,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
     getController,
 } from "~/@browser-support/sdk-helpers.js";
@@ -55,8 +56,7 @@ async function editContent(element: HTMLElement, newContent: string): Promise<vo
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    element.innerHTML = newContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, newContent);
 
     await new Promise((r) => setTimeout(r, 100));
 }
@@ -105,8 +105,8 @@ test("saved content persists in element after save", async () => {
     await clickToolbarButton("Save");
     await waitForCondition(() => !getToolbar()!.hasChanges, 5000);
 
-    // Content should still be in the element
-    expect(element.innerHTML).toBe(newContent);
+    // Content should still be in the element (may be wrapped in tags by the editor)
+    expect(element.textContent).toContain(newContent);
 });
 
 test("hasChanges is false after successful save", async () => {
@@ -146,9 +146,9 @@ test("multiple elements can be edited and saved together", async () => {
     await clickToolbarButton("Save");
     await waitForCondition(() => !toolbar!.hasChanges, 5000);
 
-    // Both should be saved
-    expect(htmlElement.innerHTML).toBe("First element edited");
-    expect(paragraphElement.innerHTML).toBe("Second element edited");
+    // Both should be saved (content may be wrapped in tags by the editor)
+    expect(htmlElement.textContent).toContain("First element edited");
+    expect(paragraphElement.textContent).toContain("Second element edited");
 });
 
 test("Save button is only visible when there are changes", async () => {

--- a/tests/browser/desktop/save/error-handling.test.ts
+++ b/tests/browser/desktop/save/error-handling.test.ts
@@ -10,6 +10,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 import { ERROR_TRIGGERS } from "~/@browser-support/test-helpers.js";
@@ -60,8 +61,7 @@ async function editContent(element: HTMLElement, content: string): Promise<void>
 
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"), 3000);
-    element.innerHTML = content;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, content);
     await new Promise((r) => setTimeout(r, 100));
 }
 
@@ -119,8 +119,8 @@ test("content is preserved after 500 error", async () => {
     // Wait for error to be processed
     await new Promise((r) => setTimeout(r, 500));
 
-    // Content should still be there
-    expect(element.innerHTML).toBe(editedContent);
+    // Content should still be there (may be wrapped in tags by the editor)
+    expect(element.textContent).toContain("Preserved content after error");
 });
 
 test("can retry save after 500 error", async () => {

--- a/tests/browser/desktop/toolbar/buttons.test.ts
+++ b/tests/browser/desktop/toolbar/buttons.test.ts
@@ -50,17 +50,17 @@ beforeEach(async () => {
 
 // --- HTML element tests ---
 
-test("Edit HTML button appears for html-type elements", async () => {
+test("Edit Content button appears for html-type elements", async () => {
     const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
     htmlElement.click();
 
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit HTML"))).toBe(true);
+    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(true);
 });
 
-test("Edit HTML button does NOT appear for text-type elements", async () => {
+test("Edit Content button does NOT appear for text-type elements", async () => {
     const textElement = document.querySelector('[data-scms-text="name"]') as HTMLElement;
     if (!textElement) {
         // Skip if no text element available
@@ -71,7 +71,7 @@ test("Edit HTML button does NOT appear for text-type elements", async () => {
     await waitForCondition(() => textElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit HTML"))).toBe(false);
+    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(false);
 });
 
 // --- Link element tests ---

--- a/tests/browser/desktop/toolbar/buttons.test.ts
+++ b/tests/browser/desktop/toolbar/buttons.test.ts
@@ -50,17 +50,17 @@ beforeEach(async () => {
 
 // --- HTML element tests ---
 
-test("Edit Content button appears for html-type elements", async () => {
+test("View Source button appears for html-type elements", async () => {
     const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
     htmlElement.click();
 
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(true);
+    expect(buttonTexts.some((t) => t.includes("View Source"))).toBe(true);
 });
 
-test("Edit Content button does NOT appear for text-type elements", async () => {
+test("View Source button does NOT appear for text-type elements", async () => {
     const textElement = document.querySelector('[data-scms-text="name"]') as HTMLElement;
     if (!textElement) {
         // Skip if no text element available
@@ -71,7 +71,7 @@ test("Edit Content button does NOT appear for text-type elements", async () => {
     await waitForCondition(() => textElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(false);
+    expect(buttonTexts.some((t) => t.includes("View Source"))).toBe(false);
 });
 
 // --- Link element tests ---
@@ -120,8 +120,8 @@ test("Save button appears when there are changes", async () => {
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     // Make a change
-    htmlElement.innerHTML = "Modified content for save test";
-    htmlElement.dispatchEvent(new Event("input", { bubbles: true }));
+    const { setElementContent } = await import("~/@browser-support/sdk-helpers.js");
+    setElementContent(htmlElement, "Modified content for save test");
 
     await new Promise((r) => setTimeout(r, 100));
 

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -51,7 +51,7 @@
 
         <!-- Elements for drafts tests (isolated) -->
         <div class="test-section">
-            <h1 data-scms-html="draft-test-title">Draft Test Title</h1>
+            <h1 data-scms-html="draft-test-title"><p>Draft Test Title</p></h1>
         </div>
 
         <!-- Template test section -->

--- a/tests/browser/support/sdk-helpers.ts
+++ b/tests/browser/support/sdk-helpers.ts
@@ -161,6 +161,26 @@ export async function clickToolbarButton(text: string): Promise<boolean> {
 }
 
 /**
+ * Edit the content of an element in a Tiptap-aware way.
+ * If the formatting toolbar has Tiptap attached to the element,
+ * uses Tiptap's API. Otherwise falls back to setting innerHTML directly.
+ */
+export function setElementContent(element: HTMLElement, newContent: string): void {
+    const toolbar = document.querySelector("scms-formatting-toolbar") as HTMLElement | null;
+    const target = toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
+
+    if (target === element) {
+        // Tiptap is managing this element — use its API
+        const setContent = (toolbar as unknown as { setContent: (html: string) => void }).setContent;
+        setContent.call(toolbar, newContent);
+    } else {
+        // No Tiptap — set innerHTML directly
+        element.innerHTML = newContent;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+}
+
+/**
  * Setup function to be called in beforeAll
  */
 export function setupTestHelpers(): void {

--- a/tests/browser/support/sdk-helpers.ts
+++ b/tests/browser/support/sdk-helpers.ts
@@ -167,11 +167,13 @@ export async function clickToolbarButton(text: string): Promise<boolean> {
  */
 export function setElementContent(element: HTMLElement, newContent: string): void {
     const toolbar = document.querySelector("scms-formatting-toolbar") as HTMLElement | null;
-    const target = toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
+    const target =
+        toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
 
     if (target === element) {
         // Tiptap is managing this element — use its API
-        const setContent = (toolbar as unknown as { setContent: (html: string) => void }).setContent;
+        const setContent = (toolbar as unknown as { setContent: (html: string) => void })
+            .setContent;
         setContent.call(toolbar, newContent);
     } else {
         // No Tiptap — set innerHTML directly


### PR DESCRIPTION
## Summary
- Introduce Tiptap-based inline rich text editor with a formatting toolbar (headings, paragraph, links, undo, etc.)
- Use Tiptap inside link and HTML editor modals; add a custom Tiptap schema
- Refactor editing/modal/content managers and remove legacy link-editing tour

## Test plan
- [x] `npm run build` is clean (aside from known postcss `infinity` warning)
- [x] `npm test` passes
- [x] Manual: inline edit text, toggle headings/paragraph, create/edit links, edit HTML, undo/redo
- [x] Manual: mobile formatting toolbar layout