### PR TITLE
Fix "Click to edit" placeholder for empty editables

### DIFF
--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -55,6 +55,36 @@ function readTextWithBreaks(element: HTMLElement): string {
     return (clone.textContent || "").replace(/\u00a0/g, " ");
 }
 
+/**
+ * Whether an editable element has no visible content. Used to toggle the
+ * "Click to edit" placeholder. Treats stray <br> tags (left behind by
+ * contenteditable when the last character is deleted) and Tiptap's empty
+ * `<p></p>` / `<p><br></p>` shells as empty.
+ */
+export function isVisuallyEmpty(element: HTMLElement): boolean {
+    for (const node of Array.from(element.childNodes)) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            if ((node.textContent || "").replace(/\u00a0/g, " ").trim() !== "") {
+                return false;
+            }
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            const el = node as HTMLElement;
+            if (el.tagName === "BR") continue;
+            if (el.tagName === "P" && isVisuallyEmpty(el)) continue;
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Toggle the `streamlined-empty` class so the placeholder rule in styles.ts
+ * matches when the element has no visible content.
+ */
+export function updateEmptyState(element: HTMLElement): void {
+    element.classList.toggle("streamlined-empty", isVisuallyEmpty(element));
+}
+
 function writeTextWithBreaks(element: HTMLElement, text: string): void {
     element.textContent = "";
     const parts = text.split("\n");
@@ -85,6 +115,10 @@ export class ContentManager {
 
         // Sync all other DOM elements from currentContent
         this.syncAllElementsFromContent(key, sourceElement);
+
+        // Refresh placeholder state for the element the user just typed in
+        // (sync handles the others via applyElementContent).
+        updateEmptyState(sourceElement);
     }
 
     /**
@@ -213,31 +247,29 @@ export class ContentManager {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
                         this.setElementHTML(info.element, linkData.value || "");
-                        return;
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
                     const imageData = data as { src?: string };
                     if (imageData.src !== undefined) {
                         info.element.src = imageData.src;
-                        return;
                     }
                 } else if (elementType === "text") {
                     const textData = data as { value?: string };
                     if (textData.value !== undefined) {
                         writeTextWithBreaks(info.element, textData.value);
-                        return;
                     }
                 } else if (elementType === "html") {
                     const htmlData = data as { value?: string };
                     if (htmlData.value !== undefined) {
                         this.setElementHTML(info.element, htmlData.value);
-                        return;
                     }
                 }
             }
         } catch {
             // Not JSON - ignore, content should always be JSON
         }
+
+        updateEmptyState(info.element);
     }
 
     /**

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -57,24 +57,27 @@ function readTextWithBreaks(element: HTMLElement): string {
 
 /**
  * Whether an editable element has no visible content. Used to toggle the
- * "Click to edit" placeholder. Treats stray <br> tags (left behind by
- * contenteditable when the last character is deleted) and Tiptap's empty
- * `<p></p>` / `<p><br></p>` shells as empty.
+ * "Click to edit" placeholder so an emptied element retains a clickable area.
+ *
+ * Treats as empty:
+ * - Truly empty elements
+ * - Stray <br> from contenteditable after the last character is deleted
+ * - Tiptap's empty wrappers (<p></p>, <p><br></p>, <span><br></span>, etc.)
+ * - Whitespace-only / nbsp-only text nodes
+ *
+ * Treats as non-empty:
+ * - Any visible text (after trimming whitespace and nbsp)
+ * - Any media-like child (img, video, svg, iframe, input, button, etc.)
  */
 export function isVisuallyEmpty(element: HTMLElement): boolean {
-    for (const node of Array.from(element.childNodes)) {
-        if (node.nodeType === Node.TEXT_NODE) {
-            if ((node.textContent || "").replace(/\u00a0/g, " ").trim() !== "") {
-                return false;
-            }
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            const el = node as HTMLElement;
-            if (el.tagName === "BR") continue;
-            if (el.tagName === "P" && isVisuallyEmpty(el)) continue;
-            return false;
-        }
+    if (
+        element.querySelector(
+            "img, video, audio, canvas, svg, iframe, input, button, picture, object, embed",
+        )
+    ) {
+        return false;
     }
-    return true;
+    return (element.textContent || "").replace(/\u00a0/g, " ").trim() === "";
 }
 
 /**

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -79,7 +79,7 @@ import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HelpPanel } from "../components/help-panel.js";
 import { createEditorState, type EditorState, type EditableElementInfo } from "./state.js";
 import { DraftManager } from "./draft-manager.js";
-import { ContentManager } from "./content-manager.js";
+import { ContentManager, updateEmptyState } from "./content-manager.js";
 import { TemplateManager } from "./template-manager.js";
 import { EditingManager } from "./editing-manager.js";
 import { ModalManager } from "./modal-manager.js";
@@ -856,6 +856,7 @@ class EditorController {
         this.state.editableElements.forEach((infos, key) => {
             for (const info of infos) {
                 info.element.classList.add("streamlined-editable");
+                updateEmptyState(info.element);
                 this.setupElementClickHandler(info.element, key);
             }
         });
@@ -877,6 +878,7 @@ class EditorController {
             for (const info of infos) {
                 info.element.classList.remove(
                     "streamlined-editable",
+                    "streamlined-empty",
                     "streamlined-selected",
                     "streamlined-selected-sibling",
                     "streamlined-editing",

--- a/src/lazy/styles.ts
+++ b/src/lazy/styles.ts
@@ -35,7 +35,7 @@ export function injectEditStyles(): void {
             outline-color: #ef4444;
         }
 
-        .streamlined-editable:empty::before {
+        .streamlined-editable.streamlined-empty::before {
             content: "Click to edit";
             color: #9ca3af;
             font-style: italic;

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -12,6 +12,7 @@ import type { Logger } from "loganite";
 import Sortable from "sortablejs";
 import type { EditorState, TemplateInfo, EditableElementInfo } from "./state.js";
 import type { ContentManager } from "./content-manager.js";
+import { updateEmptyState } from "./content-manager.js";
 import type { UndoManager } from "./undo-manager.js";
 import { EDITABLE_SELECTOR, IMAGE_PLACEHOLDER_DATA_URI, type EditableType } from "../types.js";
 
@@ -1043,6 +1044,7 @@ export class TemplateManager {
             if (!key) return;
 
             element.classList.add("streamlined-editable");
+            updateEmptyState(element);
             this.helpers.setupElementClickHandler(element, key);
         });
 

--- a/tests/browser/desktop/editing/empty-placeholder.test.ts
+++ b/tests/browser/desktop/editing/empty-placeholder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests that the "Click to edit" placeholder appears whenever an editable
+ * element has no visible content, so the element retains a clickable area.
+ *
+ * Regression test for https://github.com/streamlinedcms/client-sdk/issues/85
+ *
+ * Covers all four editable types and exercises the cases where the DOM is
+ * not literally `:empty` after deletion: stray <br> from contenteditable,
+ * Tiptap's empty <p>/<span> wrappers, etc. The acceptance criterion is the
+ * presence of the `streamlined-empty` class (which the placeholder CSS rule
+ * keys off) — that's the same signal the user would see in the rendered UI.
+ */
+
+import { test, expect, beforeAll, afterEach } from "vitest";
+import { userEvent } from "@vitest/browser/context";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+
+let appId: string;
+
+function getEl(attr: string, id: string): HTMLElement {
+    return document.querySelector(`[${attr}="${id}"]`) as HTMLElement;
+}
+
+function selectAll(el: HTMLElement): void {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+async function deleteAll(el: HTMLElement): Promise<void> {
+    selectAll(el);
+    await userEvent.keyboard("{Delete}");
+    // Tiptap commits via debounced onUpdate; give it a tick.
+    await new Promise((r) => setTimeout(r, 100));
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    appId = generateTestAppId();
+    await initializeSDK({ appId });
+});
+
+afterEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+// ---------------------------------------------------------------------------
+// Initial state — non-empty elements should NOT have the empty class
+// ---------------------------------------------------------------------------
+
+test("non-empty elements do not have streamlined-empty on init", () => {
+    expect(getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(
+        getEl("data-scms-html", "placeholder-inline-html").classList.contains("streamlined-empty"),
+    ).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-text: contenteditable leaves a stray <br>
+// ---------------------------------------------------------------------------
+
+test("text element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-text", "placeholder-text");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-html: Tiptap leaves <p></p> / <span><br></span>
+// ---------------------------------------------------------------------------
+
+test("block html element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-html", "placeholder-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+test("inline html element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-html", "placeholder-inline-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-link: also Tiptap-backed
+// ---------------------------------------------------------------------------
+
+test("link element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-link", "placeholder-link");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// Re-typing removes the empty class
+// ---------------------------------------------------------------------------
+
+test("typing into an empty element clears streamlined-empty", async () => {
+    const el = getEl("data-scms-text", "placeholder-text");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+
+    await userEvent.keyboard("Hello");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(el.classList.contains("streamlined-empty")).toBe(false);
+});
+
+test("typing then re-deleting toggles streamlined-empty back on", async () => {
+    const el = getEl("data-scms-html", "placeholder-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+
+    await userEvent.keyboard("More");
+    await new Promise((r) => setTimeout(r, 100));
+    expect(el.classList.contains("streamlined-empty")).toBe(false);
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});

--- a/tests/browser/desktop/editing/empty-placeholder.test.ts
+++ b/tests/browser/desktop/editing/empty-placeholder.test.ts
@@ -57,12 +57,15 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 test("non-empty elements do not have streamlined-empty on init", () => {
-    expect(getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"))
-        .toBe(false);
-    expect(getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"))
-        .toBe(false);
-    expect(getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"))
-        .toBe(false);
+    expect(
+        getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"),
+    ).toBe(false);
+    expect(
+        getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"),
+    ).toBe(false);
+    expect(
+        getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"),
+    ).toBe(false);
     expect(
         getEl("data-scms-html", "placeholder-inline-html").classList.contains("streamlined-empty"),
     ).toBe(false);

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -42,6 +42,15 @@
             <p data-scms-text="kb-test">Default keyboard test text</p>
         </div>
 
+        <!-- Elements for empty-placeholder tests (isolated) -->
+        <div class="test-section">
+            <h2>Empty Placeholder Test</h2>
+            <p data-scms-text="placeholder-text">Some text</p>
+            <p data-scms-html="placeholder-html">Some <strong>html</strong></p>
+            <a href="https://example.com" data-scms-link="placeholder-link">Some link</a>
+            <span data-scms-html="placeholder-inline-html">Inline html</span>
+        </div>
+
         <!-- Elements for save/basic tests (isolated) -->
         <div class="test-section">
             <h1 data-scms-html="save-basic-title">Save Basic Title</h1>


### PR DESCRIPTION
Resolves #85

## Summary
- Replace CSS `:empty` placeholder rule with a JS-managed `streamlined-empty` class
- Add `isVisuallyEmpty()` helper that treats stray `<br>`, empty `<p>` wrappers, and whitespace-only text as empty
- Toggle the class from every path that mutates editable content (input handler, content sync, `enableEditing`, template instance cloning)

## Test plan
- [x] `npm test` — all 316 tests pass
- [x] Manually verify in demo: edit a text element, delete all characters, confirm placeholder reappears
- [x] Repeat for an HTML element
- [x] Repeat for a Tiptap-backed element