### PR TITLE
Add data-scms-href link type and outer-editable selection

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -649,6 +649,55 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="info-box">
+                    <h3>Link metadata only (<code>data-scms-href</code>)</h3>
+                    <p>
+                        Use <code>data-scms-href="element-id"</code> when the link's inner content
+                        isn't editable — for example, when it contains an icon, an image, or a
+                        separately editable label. Authors can edit the URL and target, but the
+                        inner markup is preserved as-authored.
+                    </p>
+                </div>
+
+                <div class="content-section">
+                    <div class="demo-area">
+                        <h3>Icon + static text</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/docs"
+                                data-scms-href="href-demo-icon-static"
+                            >
+                                <span aria-hidden="true">📘</span>
+                                Read the docs
+                            </a>
+                        </div>
+
+                        <h3>Icon + nested editable label</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/signup"
+                                data-scms-href="href-demo-icon-label"
+                            >
+                                <span aria-hidden="true">⭐</span>
+                                <span data-scms-text="href-demo-label">Sign up now</span>
+                            </a>
+                        </div>
+
+                        <h3>Rich HTML body inside a link</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/learn"
+                                data-scms-href="href-demo-html-body"
+                            >
+                                <div data-scms-html="href-demo-html-content">
+                                    <strong>Learn more</strong> about our
+                                    <em>enterprise</em> offerings →
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- GROUPS PAGE -->

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -70,7 +70,7 @@ Use HTML only when the author needs to control the actual HTML code, or when a c
 
 **When NOT to use HTML:**
 - Individual headings, paragraphs, or labels (use `data-scms-text`)
-- A paragraph that just needs one link (use `data-scms-text` + `data-scms-link`)
+- A paragraph that just needs one link (use a `data-scms-href` anchor with a nested `data-scms-text` label)
 - Multiple separate elements that could each be their own editable (use multiple `data-scms-text`)
 
 ### Images (`data-scms-image`)
@@ -85,12 +85,63 @@ For `<img>` elements. Authors can select new images from the media manager.
 />
 ```
 
-### Links (`data-scms-link`)
+### Links (`data-scms-href`)
 
-For `<a>` elements. Authors can edit the URL, link text, and target.
+For `<a>` elements. `data-scms-href` tracks only the link's URL and target — the anchor's inner content is left entirely under your control. To make the link text editable, nest a `data-scms-text` (or `data-scms-html`) child inside the anchor.
 
 ```html
+<!-- Simple editable link: metadata on the anchor, text in a nested editable -->
+<a data-scms-href="cta" href="/signup">
+    <span data-scms-text="cta-label">Sign Up</span>
+</a>
+
+<!-- Icon + editable label -->
+<a data-scms-href="docs" href="/docs">
+    <i class="fa fa-book"></i>
+    <span data-scms-text="docs-label">Read the Docs</span>
+</a>
+
+<!-- Rich editable body inside a link -->
+<a data-scms-href="promo" href="/promo">
+    <div data-scms-html="promo-body">
+        <strong>Limited time:</strong> 20% off your first order
+    </div>
+</a>
+
+<!-- Link wrapping a logo or image (nothing editable inside) -->
+<a data-scms-href="logo-link" href="/">
+    <img src="/logo.svg" alt="Company Logo" />
+</a>
+```
+
+**Why this split?** The `<a>` element's job is navigation. Its URL/target is metadata; whatever markup sits inside is your layout. Separating them means icons, images, multi-element compositions, and rich formatted text all work inside a link without the SDK having to assume the anchor owns a single text value.
+
+**Nesting rule:** putting `data-scms-href` and another `data-scms-*` attribute on the **same element** isn't supported — only the first matching attribute will register and a console warning is emitted. Nest a child editable inside the anchor instead:
+
+```html
+<!-- Not supported — only one of the two will register -->
+<a data-scms-href="cta" data-scms-text="label" href="/x">Sign Up</a>
+
+<!-- Do this instead -->
+<a data-scms-href="cta" href="/x">
+    <span data-scms-text="label">Sign Up</span>
+</a>
+```
+
+**Selecting the outer anchor:** when a nested editable fills the entire interior of the `<a>` (e.g. a `data-scms-html` block that stretches edge-to-edge), clicks land on the inner editable. Select any inner editable and use the **Select outer element** button in the toolbar (icon with arrows pointing outward, next to the Content Viewer) to walk up to the anchor.
+
+### Deprecated: `data-scms-link`
+
+> **Legacy — prefer `data-scms-href`.** `data-scms-link` treats the anchor's inner HTML as an editable value, which conflates structure with metadata and causes rich inner markup (icons, nested editables) to be wiped when the link is inside a template. It is kept for backward compatibility; new code should use `data-scms-href` with a nested `data-scms-text` (or `data-scms-html`) for the label.
+
+```html
+<!-- Legacy -->
 <a data-scms-link="cta-button" href="/get-started">Get Started</a>
+
+<!-- Preferred -->
+<a data-scms-href="cta-button" href="/get-started">
+    <span data-scms-text="cta-label">Get Started</span>
+</a>
 ```
 
 ## Groups (`data-scms-group`)
@@ -107,9 +158,15 @@ Use the same group ID across multiple pages to share content. Edit once, update 
 <header data-scms-group="header">
     <div data-scms-text="logo">Company Name</div>
     <nav>
-        <a data-scms-link="nav-home" href="/">Home</a>
-        <a data-scms-link="nav-about" href="/about">About</a>
-        <a data-scms-link="nav-contact" href="/contact">Contact</a>
+        <a data-scms-href="nav-home" href="/">
+            <span data-scms-text="nav-home-label">Home</span>
+        </a>
+        <a data-scms-href="nav-about" href="/about">
+            <span data-scms-text="nav-about-label">About</span>
+        </a>
+        <a data-scms-href="nav-contact" href="/contact">
+            <span data-scms-text="nav-contact-label">Contact</span>
+        </a>
     </nav>
 </header>
 ```
@@ -201,6 +258,28 @@ You can use groups inside templates for content that should be identical across 
 
 In this example, the promo banner text is shared across all product cards, while the image, name, and price are unique to each instance.
 
+### Links Inside Templates
+
+Use `data-scms-href` for links inside templates. The SDK preserves the anchor's inner markup (icons, images, nested editables) across instance creation, so developer-authored layout survives. `data-scms-link` has a known issue where rich inner markup is wiped when new instances are cloned — don't use it in templates.
+
+```html
+<div data-scms-template="feature-cards">
+    <article class="feature-card">
+        <img data-scms-image="icon" src="placeholder.svg" alt="Feature icon" />
+        <h3 data-scms-text="title">Feature title</h3>
+        <div data-scms-html="description">
+            <p>Feature description with <strong>rich</strong> formatting.</p>
+        </div>
+        <!-- Link metadata on the anchor; label as a nested editable -->
+        <a data-scms-href="cta" href="/learn-more" class="btn">
+            <span data-scms-text="cta-label">Learn more</span>
+        </a>
+    </article>
+</div>
+```
+
+Each instance independently stores its own `href`, `target`, and child editable values. The icon, button styling, and surrounding layout come from the template definition and remain untouched.
+
 ## Sign-In Link
 
 Authors need a way to sign in to enable editing. You should add a sign-in link to your footer, typically in the copyright line. Add the `data-scms-signin` attribute to a link element:
@@ -237,8 +316,12 @@ The SDK automatically:
     <header data-scms-group="header">
         <div data-scms-text="logo">My Company</div>
         <nav>
-            <a data-scms-link="nav-1" href="/">Home</a>
-            <a data-scms-link="nav-2" href="/about">About</a>
+            <a data-scms-href="nav-1" href="/">
+                <span data-scms-text="nav-1-label">Home</span>
+            </a>
+            <a data-scms-href="nav-2" href="/about">
+                <span data-scms-text="nav-2-label">About</span>
+            </a>
         </nav>
     </header>
 
@@ -285,31 +368,44 @@ Keep logically separate elements as separate editables. Don't combine unrelated 
 ### Logo + Company Name
 
 ```html
-<!-- CORRECT: Separate editables for logo and name -->
+<!-- Separate editables for logo image and company name -->
 <div class="logo-container">
     <img data-scms-image="logo" src="logo.png" alt="Logo" />
     <span data-scms-text="company-name">Acme Services</span>
 </div>
 
-<!-- WRONG: Combined into one link loses individual editability -->
-<a href="/" data-scms-link="logo">
-    <img src="logo.png" />
-    <span>Acme</span>
+<!-- If the logo itself is a link, use data-scms-href so the URL is editable
+     while the image stays intact -->
+<a data-scms-href="logo-link" href="/">
+    <img data-scms-image="logo" src="logo.png" alt="Logo" />
 </a>
 ```
 
 ### Text + Link Combinations
 
 ```html
-<!-- CORRECT: Separate text and link -->
+<!-- Text before the link, link's label is its own editable -->
 <p>
     <span data-scms-text="powered-by-text">Powered by</span>
-    <a href="https://example.com" data-scms-link="powered-by-link">Example CMS</a>
+    <a data-scms-href="powered-by-link" href="https://example.com">
+        <span data-scms-text="powered-by-label">Example CMS</span>
+    </a>
 </p>
-
-<!-- WRONG: Can't edit text and link separately -->
-<a href="https://example.com" data-scms-link="powered-by">Powered by Example CMS</a>
 ```
+
+### Rich HTML inside a link
+
+When the link's body needs formatted content (bold, italic, mixed elements), nest a `data-scms-html` child. The outer `<a>` keeps its URL/target editable; the inner block gets rich-text editing.
+
+```html
+<a data-scms-href="feature-card" href="/features/analytics">
+    <div data-scms-html="feature-card-body">
+        <strong>Analytics</strong> — see everything in one dashboard.
+    </div>
+</a>
+```
+
+When a nested editable fills the entire interior of a link, clicks land on the inner editable. Select the inner element, then use the **Select outer element** button in the toolbar to jump up to the `<a>` and edit its URL.
 
 ## Link Clickability
 
@@ -318,14 +414,22 @@ For the best editing experience, put padding inside links rather than using gap 
 ```html
 <!-- CORRECT: Padding inside the link -->
 <nav class="flex items-center">
-    <a data-scms-link="nav-1" href="/" class="px-4 py-2">Home</a>
-    <a data-scms-link="nav-2" href="/about" class="px-4 py-2">About</a>
+    <a data-scms-href="nav-1" href="/" class="px-4 py-2">
+        <span data-scms-text="nav-1-label">Home</span>
+    </a>
+    <a data-scms-href="nav-2" href="/about" class="px-4 py-2">
+        <span data-scms-text="nav-2-label">About</span>
+    </a>
 </nav>
 
 <!-- WRONG: Gap creates unclickable dead zones between links -->
 <nav class="flex items-center gap-8">
-    <a data-scms-link="nav-1" href="/">Home</a>
-    <a data-scms-link="nav-2" href="/about">About</a>
+    <a data-scms-href="nav-1" href="/">
+        <span data-scms-text="nav-1-label">Home</span>
+    </a>
+    <a data-scms-href="nav-2" href="/about">
+        <span data-scms-text="nav-2-label">About</span>
+    </a>
 </nav>
 ```
 
@@ -334,14 +438,30 @@ For vertical link lists:
 ```html
 <!-- CORRECT: Block links with padding -->
 <ul>
-    <li><a data-scms-link="menu-1" href="/services" class="block py-2">Services</a></li>
-    <li><a data-scms-link="menu-2" href="/contact" class="block py-2">Contact</a></li>
+    <li>
+        <a data-scms-href="menu-1" href="/services" class="block py-2">
+            <span data-scms-text="menu-1-label">Services</span>
+        </a>
+    </li>
+    <li>
+        <a data-scms-href="menu-2" href="/contact" class="block py-2">
+            <span data-scms-text="menu-2-label">Contact</span>
+        </a>
+    </li>
 </ul>
 
 <!-- WRONG: Spacing on list items creates unclickable gaps -->
 <ul class="space-y-4">
-    <li><a data-scms-link="menu-1" href="/services">Services</a></li>
-    <li><a data-scms-link="menu-2" href="/contact">Contact</a></li>
+    <li>
+        <a data-scms-href="menu-1" href="/services">
+            <span data-scms-text="menu-1-label">Services</span>
+        </a>
+    </li>
+    <li>
+        <a data-scms-href="menu-2" href="/contact">
+            <span data-scms-text="menu-2-label">Contact</span>
+        </a>
+    </li>
 </ul>
 ```
 

--- a/src/components/accessibility-modal.ts
+++ b/src/components/accessibility-modal.ts
@@ -30,12 +30,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "primary",
             link: "secondary",
+            href: "secondary",
             text: "secondary",
             html: "secondary",
         },
         tips: {
             image: "Provides an accessible name when alt text isn't sufficient or the image has additional meaning.",
             link: "Use when the link text alone doesn't clearly describe the destination. Overrides the visible text for screen readers.",
+            href: "Use when the link content alone doesn't clearly describe the destination. Overrides child content for screen readers.",
             text: "Usually not needed since the text content itself is read. Use for additional context.",
             html: "Provides an accessible name for the entire region. Use when content alone isn't descriptive enough.",
         },
@@ -48,12 +50,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "secondary",
+            href: "secondary",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Reference the ID of another element that provides a longer description of this image.",
             link: "Reference the ID of another element that provides additional context about this link.",
+            href: "Reference the ID of another element that provides additional context about this link.",
             text: "Rarely needed for text elements since they describe themselves.",
             html: "Reference the ID of another element that provides additional context for this content.",
         },
@@ -75,12 +79,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Override the default role. Use 'presentation' or 'none' for purely decorative images.",
             link: "Links already have the correct role. Changing it is rarely appropriate.",
+            href: "Links already have the correct role. Changing it is rarely appropriate.",
             text: "Text elements rarely need a role override.",
             html: "Override the semantic role if the content serves a different purpose than its markup suggests.",
         },
@@ -97,12 +103,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "not-applicable",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Images are not typically interactive. Use only if the image has a click handler.",
             link: "Links are already focusable. Changing tabindex is rarely needed.",
+            href: "Links are already focusable. Changing tabindex is rarely needed.",
             text: "Text elements are not typically interactive.",
             html: "Use to make non-interactive content focusable or to adjust tab order.",
         },

--- a/src/components/seo-modal.ts
+++ b/src/components/seo-modal.ts
@@ -29,12 +29,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "primary",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "not-applicable",
         },
         tips: {
             image: "Describe the image for screen readers and when the image fails to load. Be concise but descriptive.",
             link: "Alt text is typically used for images, not links.",
+            href: "Alt text is typically used for images, not links.",
             text: "Alt text is typically used for images, not text elements.",
             html: "Alt text is typically used for images, not HTML elements.",
         },
@@ -47,12 +49,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "secondary",
+            href: "secondary",
             text: "secondary",
             html: "secondary",
         },
         tips: {
             image: "Shows as a tooltip on hover. Generally not needed if alt text is good.",
             link: "Shows as a tooltip on hover. Can provide additional context about the link destination.",
+            href: "Shows as a tooltip on hover. Can provide additional context about the link destination.",
             text: "Shows as a tooltip on hover. Rarely needed for text elements.",
             html: "Shows as a tooltip on hover. Rarely needed for HTML elements.",
         },
@@ -72,12 +76,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "not-applicable",
             link: "primary",
+            href: "primary",
             text: "not-applicable",
             html: "not-applicable",
         },
         tips: {
             image: "Link relationship is typically used for anchor elements, not images.",
             link: "Controls how search engines treat this link and security for external links.",
+            href: "Controls how search engines treat this link and security for external links.",
             text: "Link relationship is typically used for anchor elements, not text.",
             html: "Link relationship is typically used for anchor elements, not HTML elements.",
         },

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -475,7 +475,11 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderEditLinkButton() {
-        if (!this.activeElement || this.activeElementType !== "link") return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "link" && this.activeElementType !== "href")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
@@ -488,7 +492,11 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderGoToLinkButton() {
-        if (!this.activeElement || this.activeElementType !== "link") return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "link" && this.activeElementType !== "href")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 border border-blue-300 rounded-md hover:bg-blue-50 transition-colors inline-flex items-center gap-1"

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -17,6 +17,7 @@ import {
     ChevronUp,
     ChevronDown,
     Ellipsis,
+    Expand,
     Layers,
     Plus,
     ScanEye,
@@ -85,6 +86,9 @@ export class Toolbar extends ScmsElement {
 
     @property({ type: Boolean, attribute: "content-viewer-active" })
     contentViewerActive = false;
+
+    @property({ type: Boolean, attribute: "has-outer-editable" })
+    hasOuterEditable = false;
 
     @property({ type: Number, attribute: "hidden-element-count" })
     hiddenElementCount = 0;
@@ -382,6 +386,15 @@ export class Toolbar extends ScmsElement {
         );
     }
 
+    private handleSelectOuter() {
+        this.dispatchEvent(
+            new CustomEvent("select-outer", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
     private handleShowHiddenElements(e: Event) {
         e.stopPropagation();
         this.dispatchEvent(
@@ -655,6 +668,22 @@ export class Toolbar extends ScmsElement {
         `;
     }
 
+    private renderSelectOuterButton() {
+        if (this.warning || this.readOnly) return nothing;
+        if (!this.hasOuterEditable) return nothing;
+        return html`
+            <button
+                class="w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors [&>svg]:w-5 [&>svg]:h-5"
+                data-action="select-outer"
+                @click=${this.handleSelectOuter}
+                title="Select outer element"
+                aria-label="Select outer element"
+            >
+                ${unsafeSVG(Expand)}
+            </button>
+        `;
+    }
+
     private renderContentViewerButton() {
         // Only show in editing mode (not viewer or when warning/readOnly)
         if (this.warning || this.readOnly) return nothing;
@@ -774,7 +803,8 @@ export class Toolbar extends ScmsElement {
 
                     <!-- Right: Undo + Content Viewer + Save + Sign Out + Admin + Help -->
                     <div class="flex items-center">
-                        ${this.renderUndoButton()} ${this.renderContentViewerButton()}
+                        ${this.renderUndoButton()} ${this.renderSelectOuterButton()}
+                        ${this.renderContentViewerButton()}
                         ${this.hasChanges
                             ? html`<span class="mx-3">${this.renderSaveButton()}</span>`
                             : nothing}
@@ -1175,7 +1205,8 @@ export class Toolbar extends ScmsElement {
                         class="flex items-center w-20 justify-end gap-1"
                         @click=${(e: Event) => e.stopPropagation()}
                     >
-                        ${this.renderContentViewerButton()} ${this.renderHelpButton()}
+                        ${this.renderSelectOuterButton()} ${this.renderContentViewerButton()}
+                        ${this.renderHelpButton()}
                     </div>
                 </button>
 

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -15,6 +15,7 @@ import type {
     HtmlContentData,
     ImageContentData,
     LinkContentData,
+    HrefContentData,
 } from "../types.js";
 import { applyAttributesToElement } from "../types.js";
 
@@ -85,6 +86,12 @@ export function isVisuallyEmpty(element: HTMLElement): boolean {
  * matches when the element has no visible content.
  */
 export function updateEmptyState(element: HTMLElement): void {
+    // href elements manage their own inner markup; the SDK doesn't own the
+    // content inside, so a "Click to edit" placeholder would be misleading.
+    if (element.hasAttribute("data-scms-href")) {
+        element.classList.remove("streamlined-empty");
+        return;
+    }
     element.classList.toggle("streamlined-empty", isVisuallyEmpty(element));
 }
 
@@ -183,6 +190,14 @@ export class ContentManager {
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
+        } else if (elementType === "href" && info.element instanceof HTMLAnchorElement) {
+            const data: HrefContentData = {
+                type: "href",
+                href: info.element.getAttribute("href") || "",
+                target: info.element.target,
+                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+            };
+            return JSON.stringify(data);
         } else if (elementType === "text") {
             const data: TextContentData = {
                 type: "text",
@@ -242,6 +257,10 @@ export class ContentManager {
                 info.element.href = linkData.href;
                 info.element.target = linkData.target;
                 this.setElementHTML(info.element, linkData.value);
+            } else if (data.type === "href" && info.element instanceof HTMLAnchorElement) {
+                const hrefData = data as HrefContentData;
+                info.element.href = hrefData.href;
+                info.element.target = hrefData.target;
             } else if (!data.type) {
                 // No type field in JSON - use element's declared type
                 if (elementType === "link" && info.element instanceof HTMLAnchorElement) {
@@ -250,6 +269,12 @@ export class ContentManager {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
                         this.setElementHTML(info.element, linkData.value || "");
+                    }
+                } else if (elementType === "href" && info.element instanceof HTMLAnchorElement) {
+                    const hrefData = data as { href?: string; target?: string };
+                    if (hrefData.href !== undefined) {
+                        info.element.href = hrefData.href;
+                        info.element.target = hrefData.target || "";
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
                     const imageData = data as { src?: string };

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -93,10 +93,46 @@ export class EditingManager {
         if (this.state.toolbar) {
             this.state.toolbar.activeElement = key;
             this.state.toolbar.activeElementType = elementType;
+            this.state.toolbar.hasOuterEditable = this.findOuterEditableKey() !== null;
         }
 
         // Update template context on toolbar
         this.helpers.updateToolbarTemplateContext();
+    }
+
+    /**
+     * Find the nearest editable ancestor of the currently-selected element.
+     * Returns its storage key, or null if there's no editable ancestor or
+     * nothing is currently selected.
+     */
+    findOuterEditableKey(): string | null {
+        if (!this.state.selectedKey) return null;
+        const infos = this.state.editableElements.get(this.state.selectedKey);
+        const primary = infos?.[0];
+        if (!primary) return null;
+        const elementToKey = this.helpers.getElementToKeyMap();
+        let current = primary.element.parentElement;
+        while (current) {
+            const key = elementToKey.get(current);
+            if (key && key !== this.state.selectedKey) return key;
+            current = current.parentElement;
+        }
+        return null;
+    }
+
+    /**
+     * Select the nearest editable ancestor of the currently-selected element.
+     * Used when a nested editable fills its parent's interior and the outer
+     * element can't be clicked directly.
+     */
+    selectOuterEditable(): void {
+        const outerKey = this.findOuterEditableKey();
+        if (!outerKey) return;
+        const infos = this.state.editableElements.get(outerKey);
+        const outerElement = infos?.[0]?.element;
+        if (!outerElement) return;
+        // Use startEditing to match the normal click behavior (desktop).
+        this.startEditing(outerKey, outerElement);
     }
 
     /**
@@ -119,6 +155,7 @@ export class EditingManager {
         if (!this.state.editingKey && this.state.toolbar) {
             this.state.toolbar.activeElement = null;
             this.state.toolbar.activeElementType = null;
+            this.state.toolbar.hasOuterEditable = false;
         }
     }
 

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -250,7 +250,7 @@ export class EditingManager {
             }
 
             // Make images and links focusable for keyboard navigation
-            if (elementType === "image" || elementType === "link") {
+            if (elementType === "image" || elementType === "link" || elementType === "href") {
                 info.element.setAttribute("tabindex", "-1");
             }
         }

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1016,6 +1016,10 @@ class EditorController {
             this.contentViewerManager.toggle();
         });
 
+        toolbar.addEventListener("select-outer", () => {
+            this.editingManager.selectOuterEditable();
+        });
+
         toolbar.addEventListener("show-hidden-elements", () => {
             this.contentViewerManager.showHiddenPanel();
         });

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -645,12 +645,30 @@ class EditorController {
      * Get editable info from element by checking data-scms-{type} attributes
      */
     private getEditableInfo(element: HTMLElement): { id: string; type: EditableType } | null {
-        const types: EditableType[] = ["text", "html", "image", "link"];
+        const types: EditableType[] = ["text", "html", "image", "link", "href"];
+        const matches: { id: string; type: EditableType }[] = [];
         for (const type of types) {
             const id = element.getAttribute(`data-scms-${type}`);
-            if (id) return { id, type };
+            if (id) matches.push({ id, type });
         }
-        return null;
+        if (matches.length === 0) return null;
+        if (matches.length > 1) {
+            this.log.warn(
+                `Element has multiple data-scms-* attributes (${matches
+                    .map((m) => `data-scms-${m.type}`)
+                    .join(", ")}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
+                { element },
+            );
+        }
+        const first = matches[0];
+        if (first.type === "href" && !(element instanceof HTMLAnchorElement)) {
+            this.log.warn(
+                `data-scms-href can only be used on <a> elements. Element will be skipped.`,
+                { element },
+            );
+            return null;
+        }
+        return first;
     }
 
     /**
@@ -663,7 +681,8 @@ class EditorController {
             instanceElement.hasAttribute("data-scms-text") ||
             instanceElement.hasAttribute("data-scms-html") ||
             instanceElement.hasAttribute("data-scms-image") ||
-            instanceElement.hasAttribute("data-scms-link")
+            instanceElement.hasAttribute("data-scms-link") ||
+            instanceElement.hasAttribute("data-scms-href")
         );
     }
 
@@ -806,7 +825,11 @@ class EditorController {
                         this.state.lastTapTime = 0;
                     } else if (isMobile) {
                         // Mobile: images and links go straight to editing, others use two-step
-                        if (elementType === "image" || elementType === "link") {
+                        if (
+                            elementType === "image" ||
+                            elementType === "link" ||
+                            elementType === "href"
+                        ) {
                             this.editingManager.startEditing(key, element);
                         } else if (
                             this.state.selectedKey === key &&

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -656,7 +656,9 @@ class EditorController {
             this.log.warn(
                 `Element has multiple data-scms-* attributes (${matches
                     .map((m) => `data-scms-${m.type}`)
-                    .join(", ")}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
+                    .join(
+                        ", ",
+                    )}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
                 { element },
             );
         }

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -19,6 +19,7 @@ import type {
     HtmlContentData,
     ImageContentData,
     LinkContentData,
+    HrefContentData,
 } from "../types.js";
 import {
     ELEMENT_ATTRIBUTES,
@@ -282,6 +283,7 @@ export class ModalManager {
             return;
         }
 
+        const elementType = this.state.editableTypes.get(key) || "html";
         const primaryInfo = infos[0];
         const primaryAnchor = primaryInfo.element as HTMLAnchorElement;
         this.log.debug("Opening link editor", { key, elementId: primaryInfo.elementId });
@@ -290,7 +292,7 @@ export class ModalManager {
         const modal = document.createElement("scms-link-editor-modal") as LinkEditorModal;
         modal.elementId = key;
         // Read link value from stored content if available (avoids Tiptap normalization),
-        // fall back to DOM innerHTML
+        // fall back to DOM innerHTML. href type has no value to edit.
         let linkValue = primaryAnchor.innerHTML;
         const storedContent = this.state.currentContent.get(key);
         if (storedContent) {
@@ -318,14 +320,26 @@ export class ModalManager {
         modal.addEventListener("apply", ((e: CustomEvent<{ linkData: LinkData }>) => {
             // Build content and update via setContent
             const attributes = this.state.elementAttributes.get(key);
-            const data: LinkContentData = {
-                type: "link",
-                href: e.detail.linkData.href,
-                target: e.detail.linkData.target,
-                value: e.detail.linkData.value,
-                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
-            };
-            this.contentManager.setContent(key, JSON.stringify(data));
+            let content: string;
+            if (elementType === "href") {
+                const data: HrefContentData = {
+                    type: "href",
+                    href: e.detail.linkData.href,
+                    target: e.detail.linkData.target,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            } else {
+                const data: LinkContentData = {
+                    type: "link",
+                    href: e.detail.linkData.href,
+                    target: e.detail.linkData.target,
+                    value: e.detail.linkData.value,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            }
+            this.contentManager.setContent(key, content);
             this.closeModal("linkEditorModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("Link updated", {

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -98,14 +98,25 @@ export class TemplateManager {
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
-            el.innerHTML = "";
+            // href elements don't own their inner content — the developer-authored
+            // markup (icons, spans, nested editables) must survive into clones.
+            if (!el.hasAttribute("data-scms-href")) {
+                el.innerHTML = "";
+            }
         });
 
-        // Replace all text nodes with empty strings
+        // Replace all text nodes with empty strings, except those inside
+        // data-scms-href elements — their descendant text is developer-authored
+        // layout that must survive into instance clones. Text inside a nested
+        // editable of another type (e.g. data-scms-text inside data-scms-href)
+        // is still blanked because the nearest editable ancestor owns it.
         const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT);
         const textNodes: Text[] = [];
         while (walker.nextNode()) {
-            textNodes.push(walker.currentNode as Text);
+            const node = walker.currentNode as Text;
+            const nearestEditable = node.parentElement?.closest(EDITABLE_SELECTOR);
+            if (nearestEditable?.hasAttribute("data-scms-href")) continue;
+            textNodes.push(node);
         }
         textNodes.forEach((node) => (node.textContent = ""));
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -75,7 +75,7 @@
     /**
      * Editable element types
      */
-    type EditableType = "text" | "html" | "image" | "link";
+    type EditableType = "text" | "html" | "image" | "link" | "href";
 
     /**
      * Element info including optional group, template context, and type
@@ -166,7 +166,7 @@
         // For editable elements, strip all attributes except reserved ones
         // This handles src, href, alt, title, and any custom attributes set via modals
         const editableSelector =
-            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         div.querySelectorAll(editableSelector).forEach((el) => {
             const attributesToRemove: string[] = [];
             for (let i = 0; i < el.attributes.length; i++) {
@@ -182,14 +182,21 @@
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
-            el.innerHTML = "";
+            // href elements don't own inner content — preserve developer markup.
+            if (!el.hasAttribute("data-scms-href")) {
+                el.innerHTML = "";
+            }
         });
 
-        // Replace all text nodes with empty strings
+        // Replace all text nodes with empty strings, except those inside
+        // data-scms-href elements (where developer layout lives).
         const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT);
         const textNodes: Text[] = [];
         while (walker.nextNode()) {
-            textNodes.push(walker.currentNode as Text);
+            const node = walker.currentNode as Text;
+            const nearestEditable = node.parentElement?.closest(editableSelector);
+            if (nearestEditable?.hasAttribute("data-scms-href")) continue;
+            textNodes.push(node);
         }
         textNodes.forEach((node) => (node.textContent = ""));
 
@@ -379,10 +386,15 @@
      * Get editable info from element by checking data-scms-{type} attributes
      */
     function getEditableInfo(element: HTMLElement): { id: string; type: EditableType } | null {
-        const types: EditableType[] = ["text", "html", "image", "link"];
+        const types: EditableType[] = ["text", "html", "image", "link", "href"];
         for (const type of types) {
             const id = element.getAttribute(`data-scms-${type}`);
-            if (id) return { id, type };
+            if (id) {
+                if (type === "href" && !(element instanceof HTMLAnchorElement)) {
+                    return null;
+                }
+                return { id, type };
+            }
         }
         return null;
     }
@@ -422,7 +434,7 @@
      */
     function scanEditableElements(): Map<string, EditableElementInfo[]> {
         const elements = new Map<string, EditableElementInfo[]>();
-        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
             const info = getEditableInfo(element);
             if (info) {
@@ -596,6 +608,11 @@
                 element.target = linkData.target;
                 element.innerHTML = linkData.value;
                 return element;
+            } else if (data.type === "href" && element instanceof HTMLAnchorElement) {
+                const hrefData = data as { type: "href"; href: string; target: string };
+                element.href = hrefData.href;
+                element.target = hrefData.target;
+                return element;
             } else if (data.type) {
                 // Unknown type with type field - don't process
                 return element;
@@ -608,6 +625,12 @@
                     element.href = linkData.href;
                     element.target = linkData.target || "";
                     element.innerHTML = linkData.value || "";
+                }
+            } else if (type === "href" && element instanceof HTMLAnchorElement) {
+                const hrefData = data as { href?: string; target?: string };
+                if (hrefData.href !== undefined) {
+                    element.href = hrefData.href;
+                    element.target = hrefData.target || "";
                 }
             } else if (type === "image" && element instanceof HTMLImageElement) {
                 const imageData = data as { src?: string };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -434,7 +434,8 @@
      */
     function scanEditableElements(): Map<string, EditableElementInfo[]> {
         const elements = new Map<string, EditableElementInfo[]>();
-        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
+        const selector =
+            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
             const info = getEditableInfo(element);
             if (info) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,13 +137,13 @@ export interface BatchUpdateResponse {
 /**
  * Editable element types
  */
-export type EditableType = "text" | "html" | "image" | "link";
+export type EditableType = "text" | "html" | "image" | "link" | "href";
 
 /**
  * CSS selector for all editable elements
  */
 export const EDITABLE_SELECTOR =
-    "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+    "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
 
 /**
  * Placeholder image for new template instances (SVG data URI)
@@ -206,7 +206,18 @@ export interface LinkContentData extends BaseContentData {
     value: string;
 }
 
-export type ContentData = TextContentData | HtmlContentData | ImageContentData | LinkContentData;
+export interface HrefContentData extends BaseContentData {
+    type: "href";
+    href: string;
+    target: string;
+}
+
+export type ContentData =
+    | TextContentData
+    | HtmlContentData
+    | ImageContentData
+    | LinkContentData
+    | HrefContentData;
 
 /**
  * Template instance info for repeating content blocks

--- a/tests/browser/desktop/editing/href-elements.test.ts
+++ b/tests/browser/desktop/editing/href-elements.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Href element editing tests
+ *
+ * Covers the non-content href editable: selection, toolbar controls, modal
+ * editing, and inner-HTML preservation across apply cycles. Also covers the
+ * scanner's warnings for invalid usage (multiple data-scms-* on one element,
+ * data-scms-href on a non-anchor).
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    waitForSelector,
+    clickToolbarButton,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+import type { LinkEditorModal } from "~/src/components/link-editor-modal.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getToolbar(): Toolbar | null {
+    return document.querySelector("scms-toolbar") as Toolbar | null;
+}
+
+function getHrefElement(): HTMLAnchorElement {
+    return document.querySelector('[data-scms-href="test-href"]') as HTMLAnchorElement;
+}
+
+function getHrefEditorModal(): LinkEditorModal | null {
+    return document.querySelector("scms-link-editor-modal") as LinkEditorModal | null;
+}
+
+test("href element is registered as editable", () => {
+    const href = getHrefElement();
+    expect(href.classList.contains("streamlined-editable")).toBe(true);
+});
+
+test("clicking href element selects it with type 'href'", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    expect(toolbar?.activeElementType).toBe("href");
+});
+
+test("href element has no 'Click to edit' placeholder even if empty inside", () => {
+    const href = getHrefElement();
+    // An href-type element should never carry streamlined-empty (that would show
+    // the placeholder inside developer-authored markup).
+    expect(href.classList.contains("streamlined-empty")).toBe(false);
+});
+
+test("toolbar shows Edit Link and Go to Link buttons for href element", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const buttons = toolbar!.shadowRoot!.querySelectorAll("button");
+    const labels = Array.from(buttons).map((b) => b.textContent?.trim() ?? "");
+
+    expect(labels.some((l) => l.includes("Edit Link"))).toBe(true);
+    expect(labels.some((l) => l.includes("Go to Link"))).toBe(true);
+});
+
+test("toolbar does NOT show View Source for href element", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const buttons = toolbar!.shadowRoot!.querySelectorAll("button");
+    const hasViewSource = Array.from(buttons).some((b) =>
+        b.textContent?.trim().includes("View Source"),
+    );
+    expect(hasViewSource).toBe(false);
+});
+
+test("editing href via modal updates href and target but preserves inner HTML", async () => {
+    const href = getHrefElement();
+    const originalInnerHTML = href.innerHTML;
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    const clicked = await clickToolbarButton("Edit Link");
+    expect(clicked).toBe(true);
+
+    await waitForSelector("scms-link-editor-modal");
+    const modal = getHrefEditorModal()!;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    const urlInput = shadowRoot.querySelector('input[type="url"]') as HTMLInputElement;
+    urlInput.value = "https://example.com/updated";
+    urlInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const targetSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
+    targetSelect.value = "_blank";
+    targetSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const applyBtn = Array.from(shadowRoot.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Apply",
+    ) as HTMLButtonElement;
+    applyBtn.click();
+
+    await waitForCondition(() => getHrefEditorModal() === null);
+
+    // Attributes changed
+    expect(href.getAttribute("href")).toBe("https://example.com/updated");
+    expect(href.target).toBe("_blank");
+    // Inner HTML intact (icon + span still present)
+    expect(href.innerHTML).toBe(originalInnerHTML);
+    expect(href.querySelector('[data-testid="href-icon"]')).not.toBeNull();
+    expect(href.querySelector('[data-testid="href-label"]')).not.toBeNull();
+});
+
+test("href with both data-scms-href and data-scms-text skips href and registers text", () => {
+    // Scanner warns and registers only the first matching type (text, since it's
+    // earlier in the priority list). The href attribute is ignored.
+    const element = document.querySelector(
+        '[data-scms-href="test-href-conflict"]',
+    ) as HTMLAnchorElement;
+    expect(element).not.toBeNull();
+    // Still gets the editable class because data-scms-text registered it.
+    expect(element.classList.contains("streamlined-editable")).toBe(true);
+});
+
+test("data-scms-href on a non-anchor element is skipped", () => {
+    const bad = document.querySelector(
+        '[data-scms-href="test-href-nonanchor"]',
+    ) as HTMLElement;
+    expect(bad).not.toBeNull();
+    // Not registered, so no editable class.
+    expect(bad.classList.contains("streamlined-editable")).toBe(false);
+});

--- a/tests/browser/desktop/editing/href-elements.test.ts
+++ b/tests/browser/desktop/editing/href-elements.test.ts
@@ -145,9 +145,7 @@ test("href with both data-scms-href and data-scms-text skips href and registers 
 });
 
 test("data-scms-href on a non-anchor element is skipped", () => {
-    const bad = document.querySelector(
-        '[data-scms-href="test-href-nonanchor"]',
-    ) as HTMLElement;
+    const bad = document.querySelector('[data-scms-href="test-href-nonanchor"]') as HTMLElement;
     expect(bad).not.toBeNull();
     // Not registered, so no editable class.
     expect(bad.classList.contains("streamlined-editable")).toBe(false);

--- a/tests/browser/desktop/editing/outer-editable-button.test.ts
+++ b/tests/browser/desktop/editing/outer-editable-button.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Outer-editable navigation button tests
+ *
+ * When a nested editable fills its parent's interior (e.g. data-scms-html as
+ * the immediate child of data-scms-href), the outer editable can't be clicked
+ * directly. The toolbar exposes a "select outer" button for these cases.
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getWrapperHref(): HTMLAnchorElement {
+    return document.querySelector('[data-scms-href="test-href-wrapper"]') as HTMLAnchorElement;
+}
+
+function getWrappedHtml(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-wrapped-html"]') as HTMLElement;
+}
+
+function findButton(text: string): HTMLButtonElement | null {
+    const toolbar = getToolbar();
+    const buttons = toolbar.shadowRoot!.querySelectorAll("button");
+    for (const btn of buttons) {
+        const label = btn.getAttribute("aria-label") ?? btn.textContent?.trim() ?? "";
+        if (label.includes(text)) return btn as HTMLButtonElement;
+    }
+    return null;
+}
+
+test("outer-select button is hidden when there's no outer editable", async () => {
+    // test-link has no editable ancestor
+    const link = document.querySelector('[data-scms-link="test-link"]') as HTMLAnchorElement;
+    link.click();
+    await waitForCondition(() => link.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getToolbar().hasOuterEditable).toBe(false);
+    expect(findButton("Select outer element")).toBeNull();
+});
+
+test("outer-select button is shown when selection has an editable ancestor", async () => {
+    const innerHtml = getWrappedHtml();
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getToolbar().hasOuterEditable).toBe(true);
+    expect(findButton("Select outer element")).not.toBeNull();
+});
+
+test("clicking outer-select button selects the editable ancestor", async () => {
+    const innerHtml = getWrappedHtml();
+    const outerHref = getWrapperHref();
+
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const button = findButton("Select outer element");
+    expect(button).not.toBeNull();
+    button!.click();
+
+    await waitForCondition(() => outerHref.classList.contains("streamlined-editing"));
+    expect(getToolbar().activeElementType).toBe("href");
+    // The inner html is no longer the active editing target.
+    expect(innerHtml.classList.contains("streamlined-editing")).toBe(false);
+});
+
+test("outer-select button is hidden again at the top of the chain", async () => {
+    const innerHtml = getWrappedHtml();
+    const outerHref = getWrapperHref();
+
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    findButton("Select outer element")!.click();
+    await waitForCondition(() => outerHref.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    // href has no editable ancestor, so the button disappears.
+    expect(getToolbar().hasOuterEditable).toBe(false);
+    expect(findButton("Select outer element")).toBeNull();
+});

--- a/tests/browser/desktop/templates/href-in-template.test.ts
+++ b/tests/browser/desktop/templates/href-in-template.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Href-in-template tests
+ *
+ * Regression coverage for the template bug that motivated data-scms-href:
+ * a data-scms-link inside a template had its developer-authored inner HTML
+ * wiped out during template instance creation. data-scms-href sidesteps this
+ * because it has no value field and stripTemplateContent preserves inner
+ * markup on href-typed editables.
+ */
+
+import { test, expect, beforeAll } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    const appId = generateTestAppId();
+
+    // Seed two instances for the href-cards template.
+    await setContent(
+        appId,
+        "href-cards.card1.cta",
+        JSON.stringify({
+            type: "href",
+            href: "https://example.com/one",
+            target: "",
+        }),
+    );
+    await setContent(
+        appId,
+        "href-cards.card2.cta",
+        JSON.stringify({
+            type: "href",
+            href: "https://example.com/two",
+            target: "_blank",
+        }),
+    );
+    await setContent(
+        appId,
+        "href-cards._order",
+        JSON.stringify({ type: "order", value: ["card1", "card2"] }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+function getCards(): HTMLElement[] {
+    const container = document.querySelector('[data-scms-template="href-cards"]');
+    return Array.from(container?.querySelectorAll(".href-card") ?? []) as HTMLElement[];
+}
+
+test("seeded instances preserve developer-authored inner HTML inside data-scms-href", () => {
+    const cards = getCards();
+    expect(cards.length).toBe(2);
+
+    for (const card of cards) {
+        const anchor = card.querySelector("[data-scms-href]") as HTMLAnchorElement;
+        expect(anchor).not.toBeNull();
+        // Icon and label survived stripTemplateContent + instance cloning.
+        expect(anchor.querySelector('[data-testid="href-tmpl-icon"]')).not.toBeNull();
+        expect(anchor.querySelector('[data-testid="href-tmpl-label"]')).not.toBeNull();
+        expect(anchor.textContent?.trim()).toContain("Card CTA");
+    }
+});
+
+test("href and target apply from seeded content", () => {
+    const cards = getCards();
+    const anchors = cards.map(
+        (c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement,
+    );
+
+    expect(anchors[0].getAttribute("href")).toBe("https://example.com/one");
+    expect(anchors[0].target).toBe("");
+
+    expect(anchors[1].getAttribute("href")).toBe("https://example.com/two");
+    expect(anchors[1].target).toBe("_blank");
+});
+
+test("new instance from the add button keeps inner HTML", async () => {
+    const container = document.querySelector(
+        '[data-scms-template="href-cards"]',
+    ) as HTMLElement;
+    const initialCount = container.querySelectorAll(".href-card").length;
+
+    const addButton = container.querySelector(".scms-template-add") as HTMLElement;
+    addButton.click();
+
+    await waitForCondition(
+        () => container.querySelectorAll(".href-card").length === initialCount + 1,
+    );
+
+    const cards = container.querySelectorAll(".href-card");
+    const newCard = cards[cards.length - 1];
+    const anchor = newCard.querySelector("[data-scms-href]") as HTMLAnchorElement;
+    expect(anchor).not.toBeNull();
+
+    // Critical: inner icon + label survived into the newly cloned instance.
+    expect(anchor.querySelector('[data-testid="href-tmpl-icon"]')).not.toBeNull();
+    expect(anchor.querySelector('[data-testid="href-tmpl-label"]')).not.toBeNull();
+});

--- a/tests/browser/desktop/templates/href-in-template.test.ts
+++ b/tests/browser/desktop/templates/href-in-template.test.ts
@@ -70,9 +70,7 @@ test("seeded instances preserve developer-authored inner HTML inside data-scms-h
 
 test("href and target apply from seeded content", () => {
     const cards = getCards();
-    const anchors = cards.map(
-        (c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement,
-    );
+    const anchors = cards.map((c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement);
 
     expect(anchors[0].getAttribute("href")).toBe("https://example.com/one");
     expect(anchors[0].target).toBe("");
@@ -82,9 +80,7 @@ test("href and target apply from seeded content", () => {
 });
 
 test("new instance from the add button keeps inner HTML", async () => {
-    const container = document.querySelector(
-        '[data-scms-template="href-cards"]',
-    ) as HTMLElement;
+    const container = document.querySelector('[data-scms-template="href-cards"]') as HTMLElement;
     const initialCount = container.querySelectorAll(".href-card").length;
 
     const addButton = container.querySelector(".scms-template-add") as HTMLElement;

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -31,6 +31,42 @@
             <a href="https://example.com" data-scms-link="test-link">Default Link Text</a>
         </div>
 
+        <!-- Href element: link metadata only, inner content is developer-authored -->
+        <div class="test-section">
+            <a href="https://example.com/href" data-scms-href="test-href">
+                <i class="icon-star" data-testid="href-icon"></i>
+                <span data-testid="href-label">Learn more</span>
+            </a>
+        </div>
+
+        <!-- Href conflict: also has data-scms-text (should warn; text wins) -->
+        <div class="test-section">
+            <a
+                href="https://example.com/conflict"
+                data-scms-href="test-href-conflict"
+                data-scms-text="test-conflict-text"
+                >Conflicting Link</a
+            >
+        </div>
+
+        <!-- Href on non-anchor (should warn and skip) -->
+        <div class="test-section">
+            <div data-scms-href="test-href-nonanchor">Not an anchor</div>
+        </div>
+
+        <!-- Template containing a data-scms-href with rich inner layout -->
+        <div class="test-section">
+            <h2>Href-in-template</h2>
+            <div data-scms-template="href-cards" class="href-card-container">
+                <div class="href-card">
+                    <a href="https://example.com/card" data-scms-href="cta">
+                        <i class="icon-arrow" data-testid="href-tmpl-icon"></i>
+                        <span data-testid="href-tmpl-label">Card CTA</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <!-- Elements for content-parsing tests (isolated) -->
         <div class="test-section">
             <a href="https://example.com" data-scms-link="test-link-parsing">Default Link Text</a>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -54,6 +54,19 @@
             <div data-scms-href="test-href-nonanchor">Not an anchor</div>
         </div>
 
+        <!-- Href containing html as an immediate child (tests outer-select navigation) -->
+        <div class="test-section">
+            <a
+                href="https://example.com/wrap"
+                data-scms-href="test-href-wrapper"
+                style="display: block"
+            >
+                <div data-scms-html="test-wrapped-html" style="padding: 10px">
+                    <strong>Wrapped</strong> HTML content
+                </div>
+            </a>
+        </div>
+
         <!-- Template containing a data-scms-href with rich inner layout -->
         <div class="test-section">
             <h2>Href-in-template</h2>


### PR DESCRIPTION
## Summary

- Introduce `data-scms-href` — a non-content editable for `<a>` elements that tracks only `href`/`target`, leaving the anchor's inner HTML entirely under the developer's control. Fixes the template bug where `data-scms-link` wipes developer-authored inner markup (icons, nested editables) during instance cloning.
- Update `stripTemplateContent` (both lazy and loader code paths) so `data-scms-href` anchors preserve their descendant markup and text nodes across template cloning. Nested editables of other types inside an href still get cleaned normally.
- Add a 'Select outer element' toolbar button (arrows-out icon, next to the Content Viewer) that walks up from the current selection to the nearest editable ancestor. Covers cases where a nested editable fills its parent's interior — e.g. a `data-scms-html` inside a `data-scms-href` — so the outer anchor can still be selected.
- Rewrite the Integration guide: `data-scms-href` is documented as the recommended link API, with nested `data-scms-text` or `data-scms-html` for the label. `data-scms-link` is marked deprecated and explicitly called out as unsafe inside templates. Examples updated throughout (header nav, logo pairing, text+link, link clickability, complete page, templates).
- Reuse the existing Edit Link modal for href (URL + target only, no value). No Tiptap attachment and no 'Click to edit' placeholder for href.
- Scanner warns and skips on invalid usage: `data-scms-href` on a non-anchor, or multiple `data-scms-*` attributes on the same element.

Backwards compatible — `data-scms-link` behavior is unchanged.

## Test plan

- [x] New: `tests/browser/desktop/editing/href-elements.test.ts` (8 tests) — selection, toolbar controls, modal edit, inner-HTML preservation, non-anchor warning, multi-attr warning
- [x] New: `tests/browser/desktop/templates/href-in-template.test.ts` (3 tests) — inner HTML survives seeded instances and add-button clones
- [x] New: `tests/browser/desktop/editing/outer-editable-button.test.ts` (4 tests) — button hidden without outer editable, shown with one, click walks up, hidden at top of chain
- [x] Full suite: 50 files, 338 tests green
- [x] Manual: verify demo page — new demo section with icon+nested-text href and rich-HTML-inside-href; toolbar's Select outer button appears when the nested editable is selected