### PR TITLE
Fix first-click caret placement and text editable outline visibility

### DIFF
--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -176,7 +176,7 @@ export class FormattingToolbar extends ScmsElement {
      * Reuses existing editor for the same element (preserves undo history).
      * Creates a new editor for new elements without destroying others.
      */
-    attach(element: HTMLElement, linkMode: boolean): void {
+    attach(element: HTMLElement, linkMode: boolean, coords?: { x: number; y: number }): void {
         this.linkMode = linkMode;
         this.isMobile = window.innerWidth < 640;
         this.targetElement = element;
@@ -193,7 +193,7 @@ export class FormattingToolbar extends ScmsElement {
             if (element.getAttribute("contenteditable") !== "true") {
                 element.setAttribute("contenteditable", "true");
             }
-            this.editor.commands.focus();
+            this.focusAtCoords(coords);
             this.updateActiveFormats();
             this.style.display = "block";
             return;
@@ -235,6 +235,11 @@ export class FormattingToolbar extends ScmsElement {
         this.initialHTML = this.editor.getHTML();
         this.editors.set(element, { editor: this.editor, initialHTML: this.initialHTML });
 
+        // A freshly-created editor has no selection yet. Without an explicit
+        // focus call, ProseMirror doesn't place a caret even though the host
+        // element has DOM focus, and the user has to click a second time.
+        this.focusAtCoords(coords);
+
         // Center horizontally on first show
         if (this.posX === -1) {
             requestAnimationFrame(() => {
@@ -249,6 +254,23 @@ export class FormattingToolbar extends ScmsElement {
 
         this.updateActiveFormats();
         this.style.display = "block";
+    }
+
+    /**
+     * Focus the editor and place the caret at the given viewport coordinates.
+     * Falls back to focus("end") when no coords are given or when the coords
+     * don't resolve to a document position (e.g., keyboard/programmatic paths).
+     */
+    private focusAtCoords(coords?: { x: number; y: number }): void {
+        if (!this.editor) return;
+        if (coords) {
+            const hit = this.editor.view.posAtCoords({ left: coords.x, top: coords.y });
+            if (hit) {
+                this.editor.chain().focus().setTextSelection(hit.pos).run();
+                return;
+            }
+        }
+        this.editor.commands.focus("end");
     }
 
     /**

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -21,7 +21,12 @@ export interface EditingManagerHelpers {
     updateToolbarTemplateContext: () => void;
     getElementToKeyMap: () => WeakMap<HTMLElement, string>;
     scrollToElement: (element: HTMLElement, delay?: number) => void;
-    onStartEditing: (key: string, element: HTMLElement, elementType: string) => void;
+    onStartEditing: (
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+        coords?: { x: number; y: number },
+    ) => void;
     onStopEditing: (key: string) => void;
 }
 
@@ -205,7 +210,11 @@ export class EditingManager {
     /**
      * Start editing an element (makes it contenteditable and focuses it).
      */
-    startEditing(key: string, clickedElement?: HTMLElement): void {
+    startEditing(
+        key: string,
+        clickedElement?: HTMLElement,
+        coords?: { x: number; y: number },
+    ): void {
         const infos = this.state.editableElements.get(key);
         if (!infos || infos.length === 0) {
             this.log.warn("Element not found", { key });
@@ -296,7 +305,7 @@ export class EditingManager {
         primaryInfo.element.focus();
 
         // Notify controller that editing started (for formatting toolbar, etc.)
-        this.helpers.onStartEditing(key, primaryInfo.element, elementType);
+        this.helpers.onStartEditing(key, primaryInfo.element, elementType, coords);
 
         // On mobile, scroll the element into view after keyboard opens
         if (window.innerWidth < 640) {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -228,8 +228,8 @@ class EditorController {
             updateToolbarTemplateContext: () => this.templateManager.updateToolbarTemplateContext(),
             getElementToKeyMap: () => this.elementToKey,
             scrollToElement: this.scrollToElement.bind(this),
-            onStartEditing: (key, element, elementType) =>
-                this.handleEditingStarted(key, element, elementType),
+            onStartEditing: (key, element, elementType, coords) =>
+                this.handleEditingStarted(key, element, elementType, coords),
             onStopEditing: (key) => this.handleEditingStopped(key),
         });
 
@@ -826,19 +826,20 @@ class EditorController {
                         this.state.lastTapKey = null;
                         this.state.lastTapTime = 0;
                     } else if (isMobile) {
+                        const coords = { x: e.clientX, y: e.clientY };
                         // Mobile: images and links go straight to editing, others use two-step
                         if (
                             elementType === "image" ||
                             elementType === "link" ||
                             elementType === "href"
                         ) {
-                            this.editingManager.startEditing(key, element);
+                            this.editingManager.startEditing(key, element, coords);
                         } else if (
                             this.state.selectedKey === key &&
                             this.state.editingKey !== key
                         ) {
                             // Two-step: second tap edits
-                            this.editingManager.startEditing(key, element);
+                            this.editingManager.startEditing(key, element, coords);
                         } else {
                             // Two-step: first tap selects
                             this.editingManager.selectElement(key, element);
@@ -847,7 +848,10 @@ class EditorController {
                         this.state.lastTapTime = now;
                     } else {
                         // Desktop: edit immediately
-                        this.editingManager.startEditing(key, element);
+                        this.editingManager.startEditing(key, element, {
+                            x: e.clientX,
+                            y: e.clientY,
+                        });
                         this.state.lastTapKey = key;
                         this.state.lastTapTime = now;
                     }
@@ -1104,7 +1108,12 @@ class EditorController {
      * Attaches or reuses a Tiptap editor for html/link element types.
      * Editors are preserved across blur/focus to maintain undo history.
      */
-    private handleEditingStarted(key: string, element: HTMLElement, elementType: string): void {
+    private handleEditingStarted(
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+        coords?: { x: number; y: number },
+    ): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
             const linkMode = elementType === "link";
@@ -1119,7 +1128,7 @@ class EditorController {
             };
 
             // Attach (reuses existing editor if available, creates new otherwise)
-            toolbar.attach(element, linkMode);
+            toolbar.attach(element, linkMode, coords);
 
             // Register editor in state so content manager can use Tiptap's API.
             if (toolbar.editor) {

--- a/src/lazy/styles.ts
+++ b/src/lazy/styles.ts
@@ -61,6 +61,14 @@ export function injectEditStyles(): void {
             outline-offset: -2px;
         }
 
+        /* Non-image editables: semi-transparent solid outline for selected/editing so the caret stays visible */
+        .streamlined-editable.streamlined-selected:not([data-scms-image]),
+        .streamlined-editable.streamlined-editing:not([data-scms-image]),
+        .streamlined-editable.streamlined-editing-sibling:not([data-scms-image]) {
+            outline: 2px solid rgb(255 0 0 / 30%);
+            outline-offset: -2px;
+        }
+
         /* Template instance controls */
         .scms-instance-delete {
             position: absolute;

--- a/tests/browser/desktop/editing/first-click-caret.test.ts
+++ b/tests/browser/desktop/editing/first-click-caret.test.ts
@@ -1,0 +1,122 @@
+/**
+ * First-click caret placement tests
+ *
+ * Tiptap editors must receive focus and a ProseMirror selection on the
+ * FIRST click — users should not have to click twice to get a caret.
+ *
+ * These tests guard against regression of a bug where attach() created a
+ * new Tiptap editor but never called editor.commands.focus() on it, so
+ * the caret only appeared on the second click (which hit the reuse
+ * branch that does focus the editor).
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { FormattingToolbar } from "~/src/components/rich-text-editor.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getFormattingToolbar(): FormattingToolbar | null {
+    return document.querySelector("scms-formatting-toolbar") as FormattingToolbar | null;
+}
+
+function getParagraph(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-paragraph"]') as HTMLElement;
+}
+
+function getTitle(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
+}
+
+test("first click on an HTML element focuses the Tiptap editor", async () => {
+    const el = getTitle();
+
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    expect(toolbar).not.toBeNull();
+    expect(toolbar!.editor).not.toBeNull();
+
+    // Tiptap's focus command defers view.focus() via requestAnimationFrame,
+    // so isFocused flips async. Wait briefly for it to settle.
+    await waitForCondition(() => toolbar!.editor!.isFocused === true);
+
+    expect(toolbar!.editor!.isFocused).toBe(true);
+    expect(toolbar!.editor!.view.hasFocus()).toBe(true);
+
+    const sel = window.getSelection();
+    expect(sel).not.toBeNull();
+    expect(sel!.rangeCount).toBeGreaterThan(0);
+});
+
+test("first click places the caret at the click coordinates", async () => {
+    const el = getParagraph();
+    const rect = el.getBoundingClientRect();
+
+    // Aim for a point ~75% across the text horizontally so the resulting
+    // selection position is clearly distinguishable from pos 0 and pos end.
+    const clickX = Math.round(rect.left + rect.width * 0.75);
+    const clickY = Math.round(rect.top + rect.height / 2);
+
+    el.dispatchEvent(
+        new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            clientX: clickX,
+            clientY: clickY,
+        }),
+    );
+
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    const editor = toolbar!.editor!;
+    await waitForCondition(() => editor.isFocused === true);
+    expect(editor.isFocused).toBe(true);
+
+    const expected = editor.view.posAtCoords({ left: clickX, top: clickY });
+    expect(expected).not.toBeNull();
+
+    const actualFrom = editor.view.state.selection.from;
+    // Allow ±1 for boundary ambiguity between adjacent positions.
+    expect(Math.abs(actualFrom - expected!.pos)).toBeLessThanOrEqual(1);
+});
+
+test("keyboard navigation to next editable still focuses (fallback path)", async () => {
+    const first = getTitle();
+    const second = getParagraph();
+
+    first.click();
+    await waitForCondition(() => first.classList.contains("streamlined-editing"));
+
+    // Tab handler is attached to the editable itself (see editing-manager.ts),
+    // so dispatch on the first element — navigateToNextEditable then calls
+    // startEditing on `second` WITHOUT click coords, exercising the fallback.
+    first.dispatchEvent(
+        new KeyboardEvent("keydown", {
+            key: "Tab",
+            bubbles: true,
+            cancelable: true,
+        }),
+    );
+
+    await waitForCondition(() => second.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    expect(toolbar!.editor).not.toBeNull();
+    await waitForCondition(() => toolbar!.editor!.isFocused === true);
+    expect(toolbar!.editor!.isFocused).toBe(true);
+});


### PR DESCRIPTION
## Summary
- Place the Tiptap caret at the click point on the first click instead of requiring a second click. `attach()` created a new editor but never focused it, so the first click activated editing without a caret. New `focusAtCoords()` helper uses `view.posAtCoords()` and falls back to `focus('end')` for keyboard/programmatic paths (e.g. Tab navigation between editables). Click coordinates are plumbed through `setupElementClickHandler` → `startEditing` → `handleEditingStarted` → `attach`.
- Use a semi-transparent (30% alpha) outline for non-image editables in the selected/editing/editing-sibling states so the caret stays visible. Images retain the original solid outline.

## Test plan
- [x] New browser tests in `tests/browser/desktop/editing/first-click-caret.test.ts` — first-click focus, caret placement at click coords (±1), keyboard Tab fallback
- [x] `npm test` passes
- [x] Manual: click anywhere in a paragraph, confirm caret lands at the click point on the first click
- [x] Manual: Tab between editables, confirm caret appears
- [x] Manual: select/edit a text editable and confirm caret is visible through the outline