### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -28,9 +28,18 @@ jobs:
                   fi
 
                   # Look up PR associated with this merge commit
+                  # (retry a few times — the API may not be immediately consistent after merge)
                   echo "Looking up PR for merge commit: ${{ github.sha }}"
 
-                  PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0]' 2>/dev/null || echo "")
+                  PR_DATA=""
+                  for i in 1 2 3; do
+                      PR_DATA=$(gh api "/repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" --jq '.[0]' 2>/dev/null || echo "")
+                      if [ -n "$PR_DATA" ] && [ "$PR_DATA" != "null" ]; then
+                          break
+                      fi
+                      echo "Attempt $i: PR not found yet, retrying in 10s..."
+                      sleep 10
+                  done
 
                   if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "null" ]; then
                       echo "::error::No PR found for commit ${{ github.sha }}"
@@ -154,7 +163,6 @@ jobs:
 
     sync-develop:
         needs: [get-pr-info, deploy]
-        if: startsWith(needs.get-pr-info.outputs.head_ref, 'release/')
         runs-on: ubuntu-latest
         environment: production
 
@@ -186,6 +194,7 @@ jobs:
                   fi
 
             - name: Delete release branch
+              if: startsWith(needs.get-pr-info.outputs.head_ref, 'release/')
               env:
                   GH_TOKEN: ${{ secrets.RELEASE_PAT }}
               run: |

--- a/demo/index.html
+++ b/demo/index.html
@@ -649,6 +649,55 @@
                         </div>
                     </div>
                 </div>
+
+                <div class="info-box">
+                    <h3>Link metadata only (<code>data-scms-href</code>)</h3>
+                    <p>
+                        Use <code>data-scms-href="element-id"</code> when the link's inner content
+                        isn't editable — for example, when it contains an icon, an image, or a
+                        separately editable label. Authors can edit the URL and target, but the
+                        inner markup is preserved as-authored.
+                    </p>
+                </div>
+
+                <div class="content-section">
+                    <div class="demo-area">
+                        <h3>Icon + static text</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/docs"
+                                data-scms-href="href-demo-icon-static"
+                            >
+                                <span aria-hidden="true">📘</span>
+                                Read the docs
+                            </a>
+                        </div>
+
+                        <h3>Icon + nested editable label</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/signup"
+                                data-scms-href="href-demo-icon-label"
+                            >
+                                <span aria-hidden="true">⭐</span>
+                                <span data-scms-text="href-demo-label">Sign up now</span>
+                            </a>
+                        </div>
+
+                        <h3>Rich HTML body inside a link</h3>
+                        <div class="link-demo">
+                            <a
+                                href="https://example.com/learn"
+                                data-scms-href="href-demo-html-body"
+                            >
+                                <div data-scms-html="href-demo-html-content">
+                                    <strong>Learn more</strong> about our
+                                    <em>enterprise</em> offerings →
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
 
             <!-- GROUPS PAGE -->

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -70,7 +70,7 @@ Use HTML only when the author needs to control the actual HTML code, or when a c
 
 **When NOT to use HTML:**
 - Individual headings, paragraphs, or labels (use `data-scms-text`)
-- A paragraph that just needs one link (use `data-scms-text` + `data-scms-link`)
+- A paragraph that just needs one link (use a `data-scms-href` anchor with a nested `data-scms-text` label)
 - Multiple separate elements that could each be their own editable (use multiple `data-scms-text`)
 
 ### Images (`data-scms-image`)
@@ -85,12 +85,63 @@ For `<img>` elements. Authors can select new images from the media manager.
 />
 ```
 
-### Links (`data-scms-link`)
+### Links (`data-scms-href`)
 
-For `<a>` elements. Authors can edit the URL, link text, and target.
+For `<a>` elements. `data-scms-href` tracks only the link's URL and target — the anchor's inner content is left entirely under your control. To make the link text editable, nest a `data-scms-text` (or `data-scms-html`) child inside the anchor.
 
 ```html
+<!-- Simple editable link: metadata on the anchor, text in a nested editable -->
+<a data-scms-href="cta" href="/signup">
+    <span data-scms-text="cta-label">Sign Up</span>
+</a>
+
+<!-- Icon + editable label -->
+<a data-scms-href="docs" href="/docs">
+    <i class="fa fa-book"></i>
+    <span data-scms-text="docs-label">Read the Docs</span>
+</a>
+
+<!-- Rich editable body inside a link -->
+<a data-scms-href="promo" href="/promo">
+    <div data-scms-html="promo-body">
+        <strong>Limited time:</strong> 20% off your first order
+    </div>
+</a>
+
+<!-- Link wrapping a logo or image (nothing editable inside) -->
+<a data-scms-href="logo-link" href="/">
+    <img src="/logo.svg" alt="Company Logo" />
+</a>
+```
+
+**Why this split?** The `<a>` element's job is navigation. Its URL/target is metadata; whatever markup sits inside is your layout. Separating them means icons, images, multi-element compositions, and rich formatted text all work inside a link without the SDK having to assume the anchor owns a single text value.
+
+**Nesting rule:** putting `data-scms-href` and another `data-scms-*` attribute on the **same element** isn't supported — only the first matching attribute will register and a console warning is emitted. Nest a child editable inside the anchor instead:
+
+```html
+<!-- Not supported — only one of the two will register -->
+<a data-scms-href="cta" data-scms-text="label" href="/x">Sign Up</a>
+
+<!-- Do this instead -->
+<a data-scms-href="cta" href="/x">
+    <span data-scms-text="label">Sign Up</span>
+</a>
+```
+
+**Selecting the outer anchor:** when a nested editable fills the entire interior of the `<a>` (e.g. a `data-scms-html` block that stretches edge-to-edge), clicks land on the inner editable. Select any inner editable and use the **Select outer element** button in the toolbar (icon with arrows pointing outward, next to the Content Viewer) to walk up to the anchor.
+
+### Deprecated: `data-scms-link`
+
+> **Legacy — prefer `data-scms-href`.** `data-scms-link` treats the anchor's inner HTML as an editable value, which conflates structure with metadata and causes rich inner markup (icons, nested editables) to be wiped when the link is inside a template. It is kept for backward compatibility; new code should use `data-scms-href` with a nested `data-scms-text` (or `data-scms-html`) for the label.
+
+```html
+<!-- Legacy -->
 <a data-scms-link="cta-button" href="/get-started">Get Started</a>
+
+<!-- Preferred -->
+<a data-scms-href="cta-button" href="/get-started">
+    <span data-scms-text="cta-label">Get Started</span>
+</a>
 ```
 
 ## Groups (`data-scms-group`)
@@ -107,9 +158,15 @@ Use the same group ID across multiple pages to share content. Edit once, update 
 <header data-scms-group="header">
     <div data-scms-text="logo">Company Name</div>
     <nav>
-        <a data-scms-link="nav-home" href="/">Home</a>
-        <a data-scms-link="nav-about" href="/about">About</a>
-        <a data-scms-link="nav-contact" href="/contact">Contact</a>
+        <a data-scms-href="nav-home" href="/">
+            <span data-scms-text="nav-home-label">Home</span>
+        </a>
+        <a data-scms-href="nav-about" href="/about">
+            <span data-scms-text="nav-about-label">About</span>
+        </a>
+        <a data-scms-href="nav-contact" href="/contact">
+            <span data-scms-text="nav-contact-label">Contact</span>
+        </a>
     </nav>
 </header>
 ```
@@ -201,6 +258,28 @@ You can use groups inside templates for content that should be identical across 
 
 In this example, the promo banner text is shared across all product cards, while the image, name, and price are unique to each instance.
 
+### Links Inside Templates
+
+Use `data-scms-href` for links inside templates. The SDK preserves the anchor's inner markup (icons, images, nested editables) across instance creation, so developer-authored layout survives. `data-scms-link` has a known issue where rich inner markup is wiped when new instances are cloned — don't use it in templates.
+
+```html
+<div data-scms-template="feature-cards">
+    <article class="feature-card">
+        <img data-scms-image="icon" src="placeholder.svg" alt="Feature icon" />
+        <h3 data-scms-text="title">Feature title</h3>
+        <div data-scms-html="description">
+            <p>Feature description with <strong>rich</strong> formatting.</p>
+        </div>
+        <!-- Link metadata on the anchor; label as a nested editable -->
+        <a data-scms-href="cta" href="/learn-more" class="btn">
+            <span data-scms-text="cta-label">Learn more</span>
+        </a>
+    </article>
+</div>
+```
+
+Each instance independently stores its own `href`, `target`, and child editable values. The icon, button styling, and surrounding layout come from the template definition and remain untouched.
+
 ## Sign-In Link
 
 Authors need a way to sign in to enable editing. You should add a sign-in link to your footer, typically in the copyright line. Add the `data-scms-signin` attribute to a link element:
@@ -237,8 +316,12 @@ The SDK automatically:
     <header data-scms-group="header">
         <div data-scms-text="logo">My Company</div>
         <nav>
-            <a data-scms-link="nav-1" href="/">Home</a>
-            <a data-scms-link="nav-2" href="/about">About</a>
+            <a data-scms-href="nav-1" href="/">
+                <span data-scms-text="nav-1-label">Home</span>
+            </a>
+            <a data-scms-href="nav-2" href="/about">
+                <span data-scms-text="nav-2-label">About</span>
+            </a>
         </nav>
     </header>
 
@@ -285,31 +368,44 @@ Keep logically separate elements as separate editables. Don't combine unrelated 
 ### Logo + Company Name
 
 ```html
-<!-- CORRECT: Separate editables for logo and name -->
+<!-- Separate editables for logo image and company name -->
 <div class="logo-container">
     <img data-scms-image="logo" src="logo.png" alt="Logo" />
     <span data-scms-text="company-name">Acme Services</span>
 </div>
 
-<!-- WRONG: Combined into one link loses individual editability -->
-<a href="/" data-scms-link="logo">
-    <img src="logo.png" />
-    <span>Acme</span>
+<!-- If the logo itself is a link, use data-scms-href so the URL is editable
+     while the image stays intact -->
+<a data-scms-href="logo-link" href="/">
+    <img data-scms-image="logo" src="logo.png" alt="Logo" />
 </a>
 ```
 
 ### Text + Link Combinations
 
 ```html
-<!-- CORRECT: Separate text and link -->
+<!-- Text before the link, link's label is its own editable -->
 <p>
     <span data-scms-text="powered-by-text">Powered by</span>
-    <a href="https://example.com" data-scms-link="powered-by-link">Example CMS</a>
+    <a data-scms-href="powered-by-link" href="https://example.com">
+        <span data-scms-text="powered-by-label">Example CMS</span>
+    </a>
 </p>
-
-<!-- WRONG: Can't edit text and link separately -->
-<a href="https://example.com" data-scms-link="powered-by">Powered by Example CMS</a>
 ```
+
+### Rich HTML inside a link
+
+When the link's body needs formatted content (bold, italic, mixed elements), nest a `data-scms-html` child. The outer `<a>` keeps its URL/target editable; the inner block gets rich-text editing.
+
+```html
+<a data-scms-href="feature-card" href="/features/analytics">
+    <div data-scms-html="feature-card-body">
+        <strong>Analytics</strong> — see everything in one dashboard.
+    </div>
+</a>
+```
+
+When a nested editable fills the entire interior of a link, clicks land on the inner editable. Select the inner element, then use the **Select outer element** button in the toolbar to jump up to the `<a>` and edit its URL.
 
 ## Link Clickability
 
@@ -318,14 +414,22 @@ For the best editing experience, put padding inside links rather than using gap 
 ```html
 <!-- CORRECT: Padding inside the link -->
 <nav class="flex items-center">
-    <a data-scms-link="nav-1" href="/" class="px-4 py-2">Home</a>
-    <a data-scms-link="nav-2" href="/about" class="px-4 py-2">About</a>
+    <a data-scms-href="nav-1" href="/" class="px-4 py-2">
+        <span data-scms-text="nav-1-label">Home</span>
+    </a>
+    <a data-scms-href="nav-2" href="/about" class="px-4 py-2">
+        <span data-scms-text="nav-2-label">About</span>
+    </a>
 </nav>
 
 <!-- WRONG: Gap creates unclickable dead zones between links -->
 <nav class="flex items-center gap-8">
-    <a data-scms-link="nav-1" href="/">Home</a>
-    <a data-scms-link="nav-2" href="/about">About</a>
+    <a data-scms-href="nav-1" href="/">
+        <span data-scms-text="nav-1-label">Home</span>
+    </a>
+    <a data-scms-href="nav-2" href="/about">
+        <span data-scms-text="nav-2-label">About</span>
+    </a>
 </nav>
 ```
 
@@ -334,14 +438,30 @@ For vertical link lists:
 ```html
 <!-- CORRECT: Block links with padding -->
 <ul>
-    <li><a data-scms-link="menu-1" href="/services" class="block py-2">Services</a></li>
-    <li><a data-scms-link="menu-2" href="/contact" class="block py-2">Contact</a></li>
+    <li>
+        <a data-scms-href="menu-1" href="/services" class="block py-2">
+            <span data-scms-text="menu-1-label">Services</span>
+        </a>
+    </li>
+    <li>
+        <a data-scms-href="menu-2" href="/contact" class="block py-2">
+            <span data-scms-text="menu-2-label">Contact</span>
+        </a>
+    </li>
 </ul>
 
 <!-- WRONG: Spacing on list items creates unclickable gaps -->
 <ul class="space-y-4">
-    <li><a data-scms-link="menu-1" href="/services">Services</a></li>
-    <li><a data-scms-link="menu-2" href="/contact">Contact</a></li>
+    <li>
+        <a data-scms-href="menu-1" href="/services">
+            <span data-scms-text="menu-1-label">Services</span>
+        </a>
+    </li>
+    <li>
+        <a data-scms-href="menu-2" href="/contact">
+            <span data-scms-text="menu-2-label">Contact</span>
+        </a>
+    </li>
 </ul>
 ```
 

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -357,23 +357,69 @@ The SDK is designed to work on all modern browsers (desktop and mobile).
 
 ## JavaScript API
 
-The SDK exposes a `window.StreamlinedCMS` object for programmatic control. Wait for the `streamlined-cms:ready` event before accessing it.
+The SDK loads in two phases:
+
+1. **Loader** (synchronous script) — fetches saved content from the API, populates the DOM, and removes FOUC-hiding styles. This is the critical rendering path.
+2. **ESM module** (async, injected by the loader) — handles authentication, editing UI, and cross-origin bridges. This phase creates the `window.StreamlinedCMS` object.
+
+The loader always finishes before the ESM module begins, so any `StreamlinedCMS.ready()` stage implicitly guarantees that content is already populated in the DOM.
+
+### SDK Lifecycle Timeline
+
+```
+Loader phase:
+  1. Fetch content from API
+  2. Clone template instances
+  3. Populate DOM elements with saved content
+  4. Remove hiding styles (content is now visible)
+  5. Dispatch 'streamlined-cms:loader-complete' event
+  6. Inject ESM module script
+
+ESM phase:
+  7. ready('loaded')  — SDK controller created
+  8. ready('auth')     — authentication status determined
+  9. ready('editing')  — editing setup complete (auth required)
+ 10. ready('bridges')  — cross-origin bridges ready (auth required)
+```
+
+### Choosing the Right Event
+
+| You need to... | Use |
+|---|---|
+| Read content from the DOM after it has been populated | `streamlined-cms:loader-complete` event |
+| Access the `StreamlinedCMS` API object | `streamlined-cms:ready` event or `await StreamlinedCMS.ready()` |
+| Check if the user is authenticated | `await StreamlinedCMS.ready('auth')` then read `StreamlinedCMS.isAuthenticated` |
+| Wait for editing to be fully set up | `await StreamlinedCMS.ready('editing')` |
+| Make cross-origin API calls via bridges | `await StreamlinedCMS.ready('bridges')` |
+
+### Loader Event
+
+The `streamlined-cms:loader-complete` event fires when the loader has finished populating the DOM. This is the earliest point at which saved content is visible. The `StreamlinedCMS` object does not exist yet at this point.
+
+```javascript
+document.addEventListener('streamlined-cms:loader-complete', function() {
+    // Content is populated and visible in the DOM
+    // StreamlinedCMS API is NOT yet available
+});
+```
 
 ### Waiting for the SDK
 
+The `streamlined-cms:ready` event fires once the ESM module has loaded and the `StreamlinedCMS` controller is created. Content is already populated at this point.
+
 ```javascript
 document.addEventListener('streamlined-cms:ready', function() {
-    // StreamlinedCMS is now available
+    // StreamlinedCMS is now available, content is already in the DOM
     console.log('SDK version:', StreamlinedCMS.version);
 });
 ```
 
 ### Lifecycle Stages
 
-Use `ready(stage)` to wait for specific SDK lifecycle stages:
+Use `ready(stage)` to wait for specific stages within the ESM module:
 
 ```javascript
-// Wait for SDK to load (default)
+// Wait for SDK to load — content is already populated (default)
 await StreamlinedCMS.ready();
 
 // Wait for authentication status to be determined
@@ -387,10 +433,10 @@ await StreamlinedCMS.ready('bridges');
 ```
 
 **Stages:**
-- `loaded` - SDK module loaded, controller created (default)
-- `auth` - Authentication status determined (check `isAuthenticated` after)
-- `editing` - Editing setup complete (requires authentication)
-- `bridges` - Penpal bridges ready for API calls (requires authentication)
+- `loaded` — SDK controller created; content is already in the DOM (default)
+- `auth` — authentication status determined (check `isAuthenticated` after)
+- `editing` — editing setup complete (throws if not authenticated)
+- `bridges` — cross-origin bridges ready for API calls (throws if not authenticated)
 
 ### State Getters
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,11 @@
       "hasInstallScript": true,
       "license": "LGPL-3.0",
       "dependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-link": "^3.22.1",
+        "@tiptap/extension-underline": "^3.22.1",
+        "@tiptap/pm": "^3.22.1",
+        "@tiptap/starter-kit": "^3.22.1",
         "@vue/reactivity": "^3.5.26",
         "driver.js": "^1.4.0",
         "lit": "^3.3.1",
@@ -1345,6 +1350,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@remirror/core-constants": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+      "integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
+      "license": "MIT"
+    },
     "node_modules/@rollup/plugin-node-resolve": {
       "version": "15.3.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
@@ -2071,6 +2082,379 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.22.1.tgz",
+      "integrity": "sha512-6wPNhkdLIGYiKAGqepDCRtR0TYGJxV40SwOEN2vlPhsXqAgzmyG37UyREj5pGH5xTekugqMCgCnyRg7m5nYoYQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-blockquote": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.22.1.tgz",
+      "integrity": "sha512-omPsJ/IMAZYhXqOaEenYE+HA9U2zju5rQbAn6Xktynvr4A5P95jqkgAwncXB82pCkNYU/uYxi51vyTweTeEUHA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bold": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.22.1.tgz",
+      "integrity": "sha512-0+q6Apu1Vx2+ReB2ktTpBrQ5/dCvGzTkJCy+MZ/t8WBcybqFXOKYRCr/i/VGPDpXZttxpk0EPl0+ao+NVcUTAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-bullet-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.22.1.tgz",
+      "integrity": "sha512-83L+4N2JziWORbWtlsM0xBm3LOKIw4YtIm+Kh4amV5kGvIgIL5I1KYzoxv20qjgFX2k08LtLMwPdvPSPSh4e7g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.22.1.tgz",
+      "integrity": "sha512-Ze+hjSLLCn+5gVpuE/Uv7mQ83AlG5A9OPsuDoyzTpJ2XNvZP2iZdwQMGqwXKC8eH7fIOJN6XQ3IDv/EhltQx/Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-code-block": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.22.1.tgz",
+      "integrity": "sha512-fr3b1seFsAeYHtPAb9fbATkGcgyfStD05GHsZXFLh7yCpf2ejWLNxdWJT/g+FggSEHYFKCXT06aixk0WbtRcWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-document": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.22.1.tgz",
+      "integrity": "sha512-fBI/+PGtK6pzitqjSSSYL2+uZglX6T53zb5nLEmN/q8q7FzUuUpglp8toHVhBG05WDk4vx6Z7bC95uyxkYdoAA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-dropcursor": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.22.1.tgz",
+      "integrity": "sha512-PuSNoTROZB564KpTG9ExVB3CsfRa0ridHx+1sWZajOBVZJiXSn4QlS/ShS509SOx8z17DyxEw06IH//OHY9XyQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-gapcursor": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.22.1.tgz",
+      "integrity": "sha512-qqsyy7unWM3elv+7ru+6paKAnw1PZTvjNVQu3UzB6d556Gx2uE4isXJNdBaslBZdp2EoaYdIkhhEccW9B/Nwqg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extensions": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-hard-break": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.22.1.tgz",
+      "integrity": "sha512-hzLwLEZVbZODa9q5UiCQpOUmDnyxN19FA4LhlqLP0/JSHewP/aol5igFZwuw0XVFp425BuzPjrB7tmr0GRTDWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-heading": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.22.1.tgz",
+      "integrity": "sha512-EaIihzrOfXUHQlL6fFyJCkDrjgg0e/eD4jpkjhKpeuJDcqf7eJ1c0E2zcNRAiZkeXdN/hTQFaXKsSyNUE7T7Sg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-horizontal-rule": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.22.1.tgz",
+      "integrity": "sha512-Q18A8IN+gnfptIksPeVAI6oOBGYKAGf+QN0FEJ5OXO4BEAmA3hflflA1rWNfPC4aQNry/N7sAl8Gpd6HuIbz2w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-italic": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.22.1.tgz",
+      "integrity": "sha512-EXPZWEsWJK9tUMypddOBvayaBeu8wFV2uH5PNrtDKrfRZ1Bf8GQ3lfcO0blHssaQ9nWqa9HwBC1mdfWcmfpxig==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-link": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.22.1.tgz",
+      "integrity": "sha512-RHch/Bqv+QDvW3J1CXmiTB54pyrQYNQq8Vfa7is/O209dNPA8tdbkRP44rDjqn8NeDCriC/oJ4avWeXL4qNDVw==",
+      "license": "MIT",
+      "dependencies": {
+        "linkifyjs": "^4.3.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.22.1.tgz",
+      "integrity": "sha512-6bVI5A12sFeyb0EngABV8/qCtC2IgiDbWC8mtNNLh5dAVGaUKo1KucL6vRYDhzXhyO/eHuGYepXZDLOOdS9LIQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-item": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.22.1.tgz",
+      "integrity": "sha512-v0FgSX3cqLY3L1hIe2PFRTR3/+wlFOdFjv0p3fSJ5Tl7cgU7DR1OcljFqpw0exePcmt6dXqXVQua3PxSVV15eA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-list-keymap": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.22.1.tgz",
+      "integrity": "sha512-00Nz4jJygYGJg6N1mdbQUslFG9QaGZq5P9MFwqoduWku7gYHWkZoZvrkxZrYtxGTHVIlLnF8LIfblAlOwNd76g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-ordered-list": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.22.1.tgz",
+      "integrity": "sha512-sbd99ZUa1lIemH7N6dLB+9aYxUgduwW2216VM3dLJBS9hmTA4iDRxWx0a1ApnAVv+sZasRSbb/wpYLtXviA1XQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/extension-list": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-paragraph": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.22.1.tgz",
+      "integrity": "sha512-mnvGEZfZFysHGvmEqrSLjeddaNPB3UmomTInv9gsImw8hlB4/gQedvB6Qf2tFfIjl4ISKC5AbFxraSnJfjaL5g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-strike": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.22.1.tgz",
+      "integrity": "sha512-LTdnGmglK1f/AW//36k+Km8URA1wrTLENi3R5N+/ipv+yP2rZ2Ki1R1m6yJx3KSFzR55c91xE6659/vz1uZ6iA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-text": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.22.1.tgz",
+      "integrity": "sha512-wFCNCATSTTFhvA9wOPkAgzPVyG3RM6+jOlDeRhHUCHsFWFWj0w9ZPwA/nP+Qi5hEW7kGG9V8o62RjBdHNvK2PQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extension-underline": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.22.1.tgz",
+      "integrity": "sha512-p8/ErqQInWJbpncBycIggmtCjdrMwHmA3GNhOugo6F4fYfeVxgy7pVb7ZF+ss62d0mpQvEd81pyrzhkBtb0nBg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/extensions": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.22.1.tgz",
+      "integrity": "sha512-BKpp371Pl1CVcLRLrWH7PC1I+IsXOhet80+pILqCMlwkJnsVtOOVRr5uCF6rbPP4xK5H/ehkQWmxA8rqpv42aA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.22.1.tgz",
+      "integrity": "sha512-OSqSg2974eLJT5PNKFLM7156lBXCUf/dsKTQXWSzsLTf6HOP4dYP6c0YbAk6lgbNI+BdszsHNClmLVLA8H/L9A==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-collab": "^1.3.1",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-inputrules": "^1.4.0",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-markdown": "^1.13.1",
+        "prosemirror-menu": "^1.2.4",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-basic": "^1.2.3",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-trailing-node": "^3.0.0",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/starter-kit": {
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.22.1.tgz",
+      "integrity": "sha512-1fFmURkgofxgP9GW993bSpxf2rIJzQbWZ9rPw17qbAVuGouIArG+Fd/A1WUD95Vdbx6JIrc1QxbNlLs7bhcoPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tiptap/core": "^3.22.1",
+        "@tiptap/extension-blockquote": "^3.22.1",
+        "@tiptap/extension-bold": "^3.22.1",
+        "@tiptap/extension-bullet-list": "^3.22.1",
+        "@tiptap/extension-code": "^3.22.1",
+        "@tiptap/extension-code-block": "^3.22.1",
+        "@tiptap/extension-document": "^3.22.1",
+        "@tiptap/extension-dropcursor": "^3.22.1",
+        "@tiptap/extension-gapcursor": "^3.22.1",
+        "@tiptap/extension-hard-break": "^3.22.1",
+        "@tiptap/extension-heading": "^3.22.1",
+        "@tiptap/extension-horizontal-rule": "^3.22.1",
+        "@tiptap/extension-italic": "^3.22.1",
+        "@tiptap/extension-link": "^3.22.1",
+        "@tiptap/extension-list": "^3.22.1",
+        "@tiptap/extension-list-item": "^3.22.1",
+        "@tiptap/extension-list-keymap": "^3.22.1",
+        "@tiptap/extension-ordered-list": "^3.22.1",
+        "@tiptap/extension-paragraph": "^3.22.1",
+        "@tiptap/extension-strike": "^3.22.1",
+        "@tiptap/extension-text": "^3.22.1",
+        "@tiptap/extension-underline": "^3.22.1",
+        "@tiptap/extensions": "^3.22.1",
+        "@tiptap/pm": "^3.22.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -2104,6 +2488,28 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
       "license": "MIT"
     },
     "node_modules/@types/resolve": {
@@ -2412,6 +2818,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2783,6 +3195,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "license": "MIT"
     },
     "node_modules/css-declaration-sorter": {
       "version": "6.4.1",
@@ -3313,6 +3731,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/estree-walker": {
@@ -4124,6 +4554,21 @@
         "node": ">=10"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "node_modules/linkifyjs": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.2.tgz",
+      "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
+      "license": "MIT"
+    },
     "node_modules/lit": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.1.tgz",
@@ -4243,6 +4688,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4259,6 +4733,12 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "3.0.0",
@@ -4443,6 +4923,12 @@
         "https://github.com/sponsors/sxzz",
         "https://opencollective.com/debug"
       ],
+      "license": "MIT"
+    },
+    "node_modules/orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
     "node_modules/p-finally": {
@@ -5272,11 +5758,215 @@
         "node": ">=0.12"
       }
     },
+    "node_modules/prosemirror-changeset": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.0.tgz",
+      "integrity": "sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-collab": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+      "integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "node_modules/prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "node_modules/prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "node_modules/prosemirror-inputrules": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
+      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "node_modules/prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-menu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.3.0.tgz",
+      "integrity": "sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==",
+      "license": "MIT",
+      "dependencies": {
+        "crelt": "^1.0.0",
+        "prosemirror-commands": "^1.0.0",
+        "prosemirror-history": "^1.0.0",
+        "prosemirror-state": "^1.0.0"
+      }
+    },
+    "node_modules/prosemirror-model": {
+      "version": "1.25.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
+      "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
+      "license": "MIT",
+      "dependencies": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "node_modules/prosemirror-schema-basic": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+      "integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.25.0"
+      }
+    },
+    "node_modules/prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "node_modules/prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "node_modules/prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "node_modules/prosemirror-trailing-node": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+      "integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remirror/core-constants": "3.0.0",
+        "escape-string-regexp": "^4.0.0"
+      },
+      "peerDependencies": {
+        "prosemirror-model": "^1.22.1",
+        "prosemirror-state": "^1.4.2",
+        "prosemirror-view": "^1.33.8"
+      }
+    },
+    "node_modules/prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "node_modules/prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5418,6 +6108,12 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
       "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
     "node_modules/rrweb-cssom": {
@@ -5962,6 +6658,12 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.14.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.14.0.tgz",
@@ -6187,6 +6889,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,11 @@
     "wrangler": "^4.58.0"
   },
   "dependencies": {
+    "@tiptap/core": "^3.22.1",
+    "@tiptap/extension-link": "^3.22.1",
+    "@tiptap/extension-underline": "^3.22.1",
+    "@tiptap/pm": "^3.22.1",
+    "@tiptap/starter-kit": "^3.22.1",
     "@vue/reactivity": "^3.5.26",
     "driver.js": "^1.4.0",
     "lit": "^3.3.1",

--- a/src/components/accessibility-modal.ts
+++ b/src/components/accessibility-modal.ts
@@ -335,14 +335,7 @@ export class AccessibilityModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Accessibility</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Accessibility</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/accessibility-modal.ts
+++ b/src/components/accessibility-modal.ts
@@ -30,12 +30,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "primary",
             link: "secondary",
+            href: "secondary",
             text: "secondary",
             html: "secondary",
         },
         tips: {
             image: "Provides an accessible name when alt text isn't sufficient or the image has additional meaning.",
             link: "Use when the link text alone doesn't clearly describe the destination. Overrides the visible text for screen readers.",
+            href: "Use when the link content alone doesn't clearly describe the destination. Overrides child content for screen readers.",
             text: "Usually not needed since the text content itself is read. Use for additional context.",
             html: "Provides an accessible name for the entire region. Use when content alone isn't descriptive enough.",
         },
@@ -48,12 +50,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "secondary",
+            href: "secondary",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Reference the ID of another element that provides a longer description of this image.",
             link: "Reference the ID of another element that provides additional context about this link.",
+            href: "Reference the ID of another element that provides additional context about this link.",
             text: "Rarely needed for text elements since they describe themselves.",
             html: "Reference the ID of another element that provides additional context for this content.",
         },
@@ -75,12 +79,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Override the default role. Use 'presentation' or 'none' for purely decorative images.",
             link: "Links already have the correct role. Changing it is rarely appropriate.",
+            href: "Links already have the correct role. Changing it is rarely appropriate.",
             text: "Text elements rarely need a role override.",
             html: "Override the semantic role if the content serves a different purpose than its markup suggests.",
         },
@@ -97,12 +103,14 @@ const ACCESSIBILITY_FIELDS: FieldConfig[] = [
         priority: {
             image: "not-applicable",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "secondary",
         },
         tips: {
             image: "Images are not typically interactive. Use only if the image has a click handler.",
             link: "Links are already focusable. Changing tabindex is rarely needed.",
+            href: "Links are already focusable. Changing tabindex is rarely needed.",
             text: "Text elements are not typically interactive.",
             html: "Use to make non-interactive content focusable or to adjust tab order.",
         },

--- a/src/components/attributes-modal.ts
+++ b/src/components/attributes-modal.ts
@@ -428,14 +428,7 @@ export class AttributesModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Custom Attributes</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Custom Attributes</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/html-editor-modal.ts
+++ b/src/components/html-editor-modal.ts
@@ -144,14 +144,7 @@ export class HtmlEditorModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Edit HTML</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">View Source</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -140,10 +140,7 @@ export class LinkEditorModal extends ScmsElement {
     }
 
     private hasChanges(): boolean {
-        return (
-            this.editedHref !== this.linkData.href ||
-            this.editedTarget !== this.linkData.target
-        );
+        return this.editedHref !== this.linkData.href || this.editedTarget !== this.linkData.target;
     }
 
     private handleBackdropClick(e: Event) {

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -108,11 +108,6 @@ export class LinkEditorModal extends ScmsElement {
         this.editedTarget = select.value;
     }
 
-    private handleValueInput(e: Event) {
-        const textarea = e.target as HTMLTextAreaElement;
-        this.editedValue = textarea.value;
-    }
-
     private handleApply() {
         this.dispatchEvent(
             new CustomEvent("apply", {

--- a/src/components/link-editor-modal.ts
+++ b/src/components/link-editor-modal.ts
@@ -147,8 +147,7 @@ export class LinkEditorModal extends ScmsElement {
     private hasChanges(): boolean {
         return (
             this.editedHref !== this.linkData.href ||
-            this.editedTarget !== this.linkData.target ||
-            this.editedValue !== this.linkData.value
+            this.editedTarget !== this.linkData.target
         );
     }
 
@@ -176,14 +175,7 @@ export class LinkEditorModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">Edit Link</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">Edit Link</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}
@@ -202,20 +194,6 @@ export class LinkEditorModal extends ScmsElement {
 
                 <!-- Form -->
                 <div class="p-4 space-y-4">
-                    <!-- Link Content -->
-                    <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-1">
-                            Link Content (HTML)
-                        </label>
-                        <textarea
-                            class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-gray-400 focus:border-gray-400 font-mono text-sm"
-                            rows="3"
-                            .value=${this.editedValue}
-                            @input=${this.handleValueInput}
-                            placeholder="Click here"
-                        ></textarea>
-                    </div>
-
                     <!-- URL -->
                     <div>
                         <label class="block text-sm font-medium text-gray-700 mb-1"> URL </label>

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -176,7 +176,7 @@ export class FormattingToolbar extends ScmsElement {
      * Reuses existing editor for the same element (preserves undo history).
      * Creates a new editor for new elements without destroying others.
      */
-    attach(element: HTMLElement, linkMode: boolean): void {
+    attach(element: HTMLElement, linkMode: boolean, coords?: { x: number; y: number }): void {
         this.linkMode = linkMode;
         this.isMobile = window.innerWidth < 640;
         this.targetElement = element;
@@ -193,7 +193,7 @@ export class FormattingToolbar extends ScmsElement {
             if (element.getAttribute("contenteditable") !== "true") {
                 element.setAttribute("contenteditable", "true");
             }
-            this.editor.commands.focus();
+            this.focusAtCoords(coords);
             this.updateActiveFormats();
             this.style.display = "block";
             return;
@@ -235,6 +235,11 @@ export class FormattingToolbar extends ScmsElement {
         this.initialHTML = this.editor.getHTML();
         this.editors.set(element, { editor: this.editor, initialHTML: this.initialHTML });
 
+        // A freshly-created editor has no selection yet. Without an explicit
+        // focus call, ProseMirror doesn't place a caret even though the host
+        // element has DOM focus, and the user has to click a second time.
+        this.focusAtCoords(coords);
+
         // Center horizontally on first show
         if (this.posX === -1) {
             requestAnimationFrame(() => {
@@ -249,6 +254,23 @@ export class FormattingToolbar extends ScmsElement {
 
         this.updateActiveFormats();
         this.style.display = "block";
+    }
+
+    /**
+     * Focus the editor and place the caret at the given viewport coordinates.
+     * Falls back to focus("end") when no coords are given or when the coords
+     * don't resolve to a document position (e.g., keyboard/programmatic paths).
+     */
+    private focusAtCoords(coords?: { x: number; y: number }): void {
+        if (!this.editor) return;
+        if (coords) {
+            const hit = this.editor.view.posAtCoords({ left: coords.x, top: coords.y });
+            if (hit) {
+                this.editor.chain().focus().setTextSelection(hit.pos).run();
+                return;
+            }
+        }
+        this.editor.commands.focus("end");
     }
 
     /**

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -55,6 +55,9 @@ export class FormattingToolbar extends ScmsElement {
     private activeFormats: Set<string> = new Set();
 
     @state()
+    private isMobile = false;
+
+    @state()
     private posX = -1;
 
     @state()
@@ -76,6 +79,35 @@ export class FormattingToolbar extends ScmsElement {
     private dragStartY = 0;
     private dragStartPosX = 0;
     private dragStartPosY = 0;
+
+    /** Clamp toolbar position to stay within the visual viewport (handles keyboard open/close). */
+    private handleViewportChange = () => {
+        this.isMobile = window.innerWidth < 640;
+
+        const vv = window.visualViewport;
+        if (!vv) return;
+
+        const toolbar = this.shadowRoot?.querySelector(".toolbar-container") as HTMLElement | null;
+        const toolbarHeight = toolbar?.offsetHeight ?? 48;
+        const toolbarWidth = toolbar?.offsetWidth ?? 200;
+
+        const visibleTop = vv.offsetTop;
+        const visibleBottom = vv.offsetTop + vv.height;
+        const visibleRight = vv.offsetLeft + vv.width;
+
+        const maxY = visibleBottom - toolbarHeight;
+        const clampedY = Math.max(visibleTop, Math.min(this.posY, maxY));
+
+        let clampedX = this.posX;
+        if (!this.isMobile && this.posX !== -1) {
+            const maxX = visibleRight - toolbarWidth;
+            clampedX = Math.max(vv.offsetLeft, Math.min(this.posX, maxX));
+        }
+
+        if (clampedY !== this.posY) this.posY = clampedY;
+        if (clampedX !== this.posX) this.posX = clampedX;
+    };
+
     /**
      * Callback fired on each content update. Set by the controller
      * to sync content changes back to the content manager.
@@ -94,7 +126,8 @@ export class FormattingToolbar extends ScmsElement {
 
             .toolbar-container {
                 pointer-events: auto;
-                display: inline-flex;
+                display: flex;
+                flex-direction: column;
                 align-items: center;
                 gap: 2px;
                 padding: 4px 8px;
@@ -104,17 +137,27 @@ export class FormattingToolbar extends ScmsElement {
                 box-shadow:
                     0 4px 6px -1px rgba(0, 0, 0, 0.1),
                     0 2px 4px -2px rgba(0, 0, 0, 0.1);
+            }
+
+            .toolbar-buttons {
+                display: flex;
                 flex-wrap: wrap;
+                justify-content: center;
+                align-items: center;
+                gap: 2px;
             }
 
             .drag-handle {
                 cursor: grab;
-                padding: 4px 2px;
+                padding: 2px 0;
                 color: #9ca3af;
                 display: flex;
                 align-items: center;
+                justify-content: center;
+                width: 40px;
                 user-select: none;
                 -webkit-user-select: none;
+                touch-action: none;
             }
 
             .drag-handle:active {
@@ -134,6 +177,7 @@ export class FormattingToolbar extends ScmsElement {
      */
     attach(element: HTMLElement, linkMode: boolean): void {
         this.linkMode = linkMode;
+        this.isMobile = window.innerWidth < 640;
         this.targetElement = element;
 
         // Reuse existing editor for this element
@@ -271,10 +315,17 @@ export class FormattingToolbar extends ScmsElement {
         }
     }
 
+    connectedCallback() {
+        super.connectedCallback();
+        window.visualViewport?.addEventListener("resize", this.handleViewportChange);
+        window.visualViewport?.addEventListener("scroll", this.handleViewportChange);
+    }
+
     disconnectedCallback() {
         super.disconnectedCallback();
+        window.visualViewport?.removeEventListener("resize", this.handleViewportChange);
+        window.visualViewport?.removeEventListener("scroll", this.handleViewportChange);
         this.detach();
-
     }
 
     private updateActiveFormats() {
@@ -309,8 +360,25 @@ export class FormattingToolbar extends ScmsElement {
         const onMove = (ev: PointerEvent) => {
             const dx = ev.clientX - this.dragStartX;
             const dy = ev.clientY - this.dragStartY;
-            this.posX = Math.max(0, this.dragStartPosX + dx);
-            this.posY = Math.max(0, this.dragStartPosY + dy);
+
+            const toolbar = this.shadowRoot?.querySelector(
+                ".toolbar-container",
+            ) as HTMLElement | null;
+            const toolbarHeight = toolbar?.offsetHeight ?? 48;
+            const toolbarWidth = toolbar?.offsetWidth ?? 200;
+
+            const vv = window.visualViewport;
+            const minY = vv?.offsetTop ?? 0;
+            const maxY = (vv ? vv.offsetTop + vv.height : window.innerHeight) - toolbarHeight;
+
+            this.posY = Math.max(minY, Math.min(this.dragStartPosY + dy, maxY));
+
+            if (!this.isMobile) {
+                const minX = vv?.offsetLeft ?? 0;
+                const maxX =
+                    (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
+                this.posX = Math.max(minX, Math.min(this.dragStartPosX + dx, maxX));
+            }
         };
 
         const onUp = () => {
@@ -440,53 +508,62 @@ export class FormattingToolbar extends ScmsElement {
         return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
     }
 
+    private renderDragHandle() {
+        return html`
+            <div
+                class="drag-handle"
+                @pointerdown=${this.handleDragStart}
+                title="Drag to reposition"
+            >
+                <span class="[&>svg]:w-4 [&>svg]:h-4">
+                    ${unsafeSVG(GripHorizontal)}
+                </span>
+            </div>
+        `;
+    }
+
     render() {
         if (!this.editor) return nothing;
 
-        const left = this.posX === -1 ? "50%" : `${this.posX}px`;
-        const transform = this.posX === -1 ? "translateX(-50%)" : "none";
+        const mobile = this.isMobile;
+        const left = mobile ? "0" : this.posX === -1 ? "50%" : `${this.posX}px`;
+        const right = mobile ? "0" : "auto";
+        const transform = !mobile && this.posX === -1 ? "translateX(-50%)" : "none";
 
         return html`
             <div
                 class="toolbar-container"
-                style="position:fixed; top:${this.posY}px; left:${left}; transform:${transform};"
+                style="position:fixed; top:${this.posY}px; left:${left}; right:${right}; transform:${transform};"
             >
-                <div
-                    class="drag-handle"
-                    @pointerdown=${this.handleDragStart}
-                    title="Drag to reposition"
-                >
-                    <span class="[&>svg]:w-4 [&>svg]:h-4">
-                        ${unsafeSVG(GripHorizontal)}
-                    </span>
+                ${this.renderDragHandle()}
+                <div class="toolbar-buttons">
+                    ${this.renderButton("bold", Bold, "Bold")}
+                    ${this.renderButton("italic", Italic, "Italic")}
+                    ${this.renderButton("underline", UnderlineIcon, "Underline")}
+                    ${this.renderButton("strike", Strikethrough, "Strikethrough")}
+                    ${this.renderButton("code", Code, "Inline Code")}
+                    ${this.renderSeparator()}
+                    ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
+                    ${this.renderButton("h1", Heading1, "Heading 1")}
+                    ${this.renderButton("h2", Heading2, "Heading 2")}
+                    ${this.renderButton("h3", Heading3, "Heading 3")}
+                    ${this.linkMode
+                        ? nothing
+                        : html`
+                              ${this.renderSeparator()}
+                              ${this.renderButton("bulletList", List, "Bullet List")}
+                              ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
+                              ${this.renderButton("blockquote", Quote, "Blockquote")}
+                          `}
+                    ${this.linkMode ? nothing : this.renderSeparator()}
+                    ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                    ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.linkMode ? this.renderSeparator() : nothing}
+                    ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
+                    ${this.renderSeparator()}
+                    ${this.renderButton("undo", Undo2, "Undo")}
+                    ${this.renderButton("redo", Redo2, "Redo")}
                 </div>
-                ${this.renderSeparator()}
-                ${this.renderButton("bold", Bold, "Bold")}
-                ${this.renderButton("italic", Italic, "Italic")}
-                ${this.renderButton("underline", UnderlineIcon, "Underline")}
-                ${this.renderButton("strike", Strikethrough, "Strikethrough")}
-                ${this.renderButton("code", Code, "Inline Code")}
-                ${this.renderSeparator()}
-                ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
-                ${this.renderButton("h1", Heading1, "Heading 1")}
-                ${this.renderButton("h2", Heading2, "Heading 2")}
-                ${this.renderButton("h3", Heading3, "Heading 3")}
-                ${this.linkMode
-                    ? nothing
-                    : html`
-                          ${this.renderSeparator()}
-                          ${this.renderButton("bulletList", List, "Bullet List")}
-                          ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
-                          ${this.renderButton("blockquote", Quote, "Blockquote")}
-                      `}
-                ${this.linkMode ? nothing : this.renderSeparator()}
-                ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
-                ${this.linkMode ? this.renderSeparator() : nothing}
-                ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
-                ${this.renderSeparator()}
-                ${this.renderButton("undo", Undo2, "Undo")}
-                ${this.renderButton("redo", Redo2, "Redo")}
             </div>
         `;
     }

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -242,10 +242,7 @@ export class FormattingToolbar extends ScmsElement {
                     ".toolbar-container",
                 ) as HTMLElement | null;
                 if (toolbar) {
-                    this.posX = Math.max(
-                        12,
-                        (window.innerWidth - toolbar.offsetWidth) / 2,
-                    );
+                    this.posX = Math.max(12, (window.innerWidth - toolbar.offsetWidth) / 2);
                 }
             });
         }
@@ -384,8 +381,7 @@ export class FormattingToolbar extends ScmsElement {
 
             if (!this.isMobile) {
                 const minX = vv?.offsetLeft ?? 0;
-                const maxX =
-                    (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
+                const maxX = (vv ? vv.offsetLeft + vv.width : window.innerWidth) - toolbarWidth;
                 this.posX = Math.max(minX, Math.min(this.dragStartPosX + dx, maxX));
             }
         };
@@ -463,9 +459,7 @@ export class FormattingToolbar extends ScmsElement {
                 break;
             case "link": {
                 const currentHref = this.editor.getAttributes("link").href || "";
-                const message = currentHref
-                    ? "Edit URL (clear to remove link):"
-                    : "Enter URL:";
+                const message = currentHref ? "Edit URL (clear to remove link):" : "Enter URL:";
                 const href = prompt(message, currentHref);
                 if (href === null) {
                     // User cancelled — do nothing
@@ -524,9 +518,7 @@ export class FormattingToolbar extends ScmsElement {
                 @pointerdown=${this.handleDragStart}
                 title="Drag to reposition"
             >
-                <span class="[&>svg]:w-4 [&>svg]:h-4">
-                    ${unsafeSVG(GripHorizontal)}
-                </span>
+                <span class="[&>svg]:w-4 [&>svg]:h-4"> ${unsafeSVG(GripHorizontal)} </span>
             </div>
         `;
     }
@@ -542,7 +534,8 @@ export class FormattingToolbar extends ScmsElement {
         return html`
             <div
                 class="toolbar-container"
-                style="position:fixed; top:${this.posY}px; left:${left}; right:${right}; transform:${transform};"
+                style="position:fixed; top:${this
+                    .posY}px; left:${left}; right:${right}; transform:${transform};"
             >
                 ${this.renderDragHandle()}
                 <div class="toolbar-buttons">
@@ -550,8 +543,7 @@ export class FormattingToolbar extends ScmsElement {
                     ${this.renderButton("italic", Italic, "Italic")}
                     ${this.renderButton("underline", UnderlineIcon, "Underline")}
                     ${this.renderButton("strike", Strikethrough, "Strikethrough")}
-                    ${this.renderButton("code", Code, "Inline Code")}
-                    ${this.renderSeparator()}
+                    ${this.renderButton("code", Code, "Inline Code")} ${this.renderSeparator()}
                     ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
                     ${this.renderButton("h1", Heading1, "Heading 1")}
                     ${this.renderButton("h2", Heading2, "Heading 2")}
@@ -566,11 +558,14 @@ export class FormattingToolbar extends ScmsElement {
                           `}
                     ${this.linkMode ? nothing : this.renderSeparator()}
                     ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                    ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.linkMode
+                        ? nothing
+                        : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
                     ${this.linkMode ? this.renderSeparator() : nothing}
-                    ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
-                    ${this.renderSeparator()}
-                    ${this.renderButton("undo", Undo2, "Undo")}
+                    ${this.linkMode
+                        ? this.renderButton("goToLink", ExternalLink, "Go to Link")
+                        : nothing}
+                    ${this.renderSeparator()} ${this.renderButton("undo", Undo2, "Undo")}
                     ${this.renderButton("redo", Redo2, "Redo")}
                 </div>
             </div>

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -186,6 +186,13 @@ export class FormattingToolbar extends ScmsElement {
         if (existing) {
             this.editor = existing.editor;
             this.initialHTML = existing.initialHTML;
+            // Defensive: ensure the element is still editable. Something can
+            // leave contenteditable=false on a tiptap-managed element, which
+            // hides the cursor and blocks typing even though the editor and
+            // toolbar are still alive.
+            if (element.getAttribute("contenteditable") !== "true") {
+                element.setAttribute("contenteditable", "true");
+            }
             this.editor.commands.focus();
             this.updateActiveFormats();
             this.style.display = "block";

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -1,0 +1,495 @@
+/**
+ * Rich Text Editor Component
+ *
+ * A shared WYSIWYG editor built on Tiptap (ProseMirror).
+ * Used by both the HTML editor modal and link editor modal.
+ * Supports full and compact toolbar modes, plus a raw HTML source toggle.
+ */
+
+import { html, css, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import { ScmsElement } from "./base.js";
+import { Editor } from "@tiptap/core";
+import StarterKit from "@tiptap/starter-kit";
+import Link from "@tiptap/extension-link";
+import Underline from "@tiptap/extension-underline";
+import {
+    Bold,
+    Italic,
+    Underline as UnderlineIcon,
+    Strikethrough,
+    Code,
+    Heading1,
+    Heading2,
+    Heading3,
+    List,
+    ListOrdered,
+    Quote,
+    Link as LinkIcon,
+    Minus,
+    Undo2,
+    Redo2,
+    Code2,
+} from "lucide-static";
+
+@customElement("scms-rich-text-editor")
+export class RichTextEditor extends ScmsElement {
+    @property({ type: String })
+    content = "";
+
+    @property({ type: Boolean })
+    compact = false;
+
+    @state()
+    private sourceMode = false;
+
+    @state()
+    private sourceContent = "";
+
+    @state()
+    private activeFormats: Set<string> = new Set();
+
+    private editor: Editor | null = null;
+    private initialHTML = "";
+
+    static styles = [
+        ...ScmsElement.styles,
+        css`
+            .editor-wrapper {
+                border: 1px solid #d1d5db;
+                border-radius: 0.375rem;
+                overflow: hidden;
+            }
+
+            .editor-wrapper:focus-within {
+                border-color: #9ca3af;
+                box-shadow: 0 0 0 1px #9ca3af;
+            }
+
+            .ProseMirror {
+                outline: none;
+                padding: 0.75rem;
+                font-size: 14px;
+                line-height: 1.6;
+            }
+
+            :host([compact]) .ProseMirror {
+                min-height: 80px;
+                max-height: 200px;
+                overflow-y: auto;
+            }
+
+            :host(:not([compact])) .ProseMirror {
+                min-height: 200px;
+                max-height: 50vh;
+                overflow-y: auto;
+            }
+
+            .ProseMirror p {
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror h1 {
+                font-size: 1.5em;
+                font-weight: 700;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror h2 {
+                font-size: 1.25em;
+                font-weight: 600;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror h3 {
+                font-size: 1.1em;
+                font-weight: 600;
+                margin: 0.5em 0 0.25em;
+            }
+
+            .ProseMirror ul {
+                list-style: disc;
+                padding-left: 1.5em;
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror ol {
+                list-style: decimal;
+                padding-left: 1.5em;
+                margin: 0.25em 0;
+            }
+
+            .ProseMirror li {
+                margin: 0.1em 0;
+            }
+
+            .ProseMirror blockquote {
+                border-left: 3px solid #d1d5db;
+                padding-left: 1em;
+                color: #6b7280;
+                margin: 0.5em 0;
+            }
+
+            .ProseMirror a {
+                color: #2563eb;
+                text-decoration: underline;
+            }
+
+            .ProseMirror code {
+                background: #f3f4f6;
+                padding: 0.15em 0.35em;
+                border-radius: 0.25em;
+                font-size: 0.875em;
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                    monospace;
+            }
+
+            .ProseMirror hr {
+                border: none;
+                border-top: 1px solid #d1d5db;
+                margin: 1em 0;
+            }
+
+            .ProseMirror p.is-editor-empty:first-child::before {
+                content: attr(data-placeholder);
+                color: #9ca3af;
+                pointer-events: none;
+                float: left;
+                height: 0;
+            }
+
+            .source-textarea {
+                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+                    monospace;
+                font-size: 13px;
+                line-height: 1.5;
+                tab-size: 2;
+                padding: 0.75rem;
+                width: 100%;
+                border: none;
+                outline: none;
+                resize: none;
+            }
+
+            :host([compact]) .source-textarea {
+                min-height: 80px;
+                max-height: 200px;
+            }
+
+            :host(:not([compact])) .source-textarea {
+                min-height: 200px;
+                max-height: 50vh;
+            }
+
+            button {
+                cursor: pointer;
+            }
+        `,
+    ];
+
+    firstUpdated() {
+        const editorElement = this.shadowRoot!.querySelector("#editor") as HTMLElement;
+        if (!editorElement) return;
+
+        this.editor = new Editor({
+            element: editorElement,
+            extensions: [
+                StarterKit.configure({
+                    heading: this.compact ? false : { levels: [1, 2, 3] },
+                    bulletList: this.compact ? false : undefined,
+                    orderedList: this.compact ? false : undefined,
+                    blockquote: this.compact ? false : undefined,
+                    horizontalRule: this.compact ? false : undefined,
+                    strike: this.compact ? false : undefined,
+                    code: this.compact ? false : undefined,
+                }),
+                Link.configure({
+                    openOnClick: false,
+                    HTMLAttributes: {
+                        rel: null,
+                        target: null,
+                    },
+                }),
+                Underline,
+            ],
+            content: this.content,
+            onTransaction: () => {
+                this.updateActiveFormats();
+                this.dispatchEvent(
+                    new CustomEvent("content-change", {
+                        detail: { content: this.editor!.getHTML() },
+                        bubbles: true,
+                        composed: true,
+                    }),
+                );
+            },
+        });
+
+        this.initialHTML = this.editor.getHTML();
+        this.updateActiveFormats();
+    }
+
+    disconnectedCallback() {
+        super.disconnectedCallback();
+        this.editor?.destroy();
+        this.editor = null;
+    }
+
+    updated(changedProperties: Map<string, unknown>) {
+        if (changedProperties.has("content") && this.editor) {
+            const currentHTML = this.editor.getHTML();
+            if (currentHTML !== this.content) {
+                this.editor.commands.setContent(this.content, { emitUpdate: false });
+            }
+        }
+    }
+
+    /**
+     * Get the current editor content as HTML
+     */
+    getHTML(): string {
+        if (this.sourceMode) {
+            return this.sourceContent;
+        }
+        return this.editor?.getHTML() || this.content;
+    }
+
+    /**
+     * Whether the editor content has changed from what was initially loaded.
+     * Compares against Tiptap-normalized HTML to avoid false positives from
+     * normalization (e.g. "Hello" → "<p>Hello</p>").
+     */
+    hasChanges(): boolean {
+        return this.getHTML() !== this.initialHTML;
+    }
+
+    private updateActiveFormats() {
+        if (!this.editor) return;
+
+        const formats = new Set<string>();
+        if (this.editor.isActive("bold")) formats.add("bold");
+        if (this.editor.isActive("italic")) formats.add("italic");
+        if (this.editor.isActive("underline")) formats.add("underline");
+        if (this.editor.isActive("strike")) formats.add("strike");
+        if (this.editor.isActive("code")) formats.add("code");
+        if (this.editor.isActive("heading", { level: 1 })) formats.add("h1");
+        if (this.editor.isActive("heading", { level: 2 })) formats.add("h2");
+        if (this.editor.isActive("heading", { level: 3 })) formats.add("h3");
+        if (this.editor.isActive("bulletList")) formats.add("bulletList");
+        if (this.editor.isActive("orderedList")) formats.add("orderedList");
+        if (this.editor.isActive("blockquote")) formats.add("blockquote");
+        if (this.editor.isActive("link")) formats.add("link");
+
+        this.activeFormats = formats;
+    }
+
+    private toggleSourceMode() {
+        if (this.sourceMode) {
+            // Switching back to rich text: apply source content to editor
+            if (this.editor) {
+                this.editor.commands.setContent(this.sourceContent, { emitUpdate: false });
+            }
+            this.sourceMode = false;
+        } else {
+            // Switching to source: capture editor HTML
+            this.sourceContent = this.editor?.getHTML() || this.content;
+            this.sourceMode = true;
+        }
+    }
+
+    private handleSourceInput(e: Event) {
+        const textarea = e.target as HTMLTextAreaElement;
+        this.sourceContent = textarea.value;
+        this.dispatchEvent(
+            new CustomEvent("content-change", {
+                detail: { content: this.sourceContent },
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
+    private exec(command: string, options?: Record<string, unknown>) {
+        if (!this.editor) return;
+        const chain = this.editor.chain().focus();
+
+        switch (command) {
+            case "bold":
+                chain.toggleBold().run();
+                break;
+            case "italic":
+                chain.toggleItalic().run();
+                break;
+            case "underline":
+                chain.toggleUnderline().run();
+                break;
+            case "strike":
+                chain.toggleStrike().run();
+                break;
+            case "code":
+                chain.toggleCode().run();
+                break;
+            case "h1":
+                chain.toggleHeading({ level: 1 }).run();
+                break;
+            case "h2":
+                chain.toggleHeading({ level: 2 }).run();
+                break;
+            case "h3":
+                chain.toggleHeading({ level: 3 }).run();
+                break;
+            case "bulletList":
+                chain.toggleBulletList().run();
+                break;
+            case "orderedList":
+                chain.toggleOrderedList().run();
+                break;
+            case "blockquote":
+                chain.toggleBlockquote().run();
+                break;
+            case "horizontalRule":
+                chain.setHorizontalRule().run();
+                break;
+            case "link": {
+                if (this.editor.isActive("link")) {
+                    chain.unsetLink().run();
+                } else {
+                    const url = options?.href as string | undefined;
+                    const href = url || prompt("Enter URL:");
+                    if (href) {
+                        chain.setLink({ href }).run();
+                    }
+                }
+                break;
+            }
+            case "undo":
+                chain.undo().run();
+                break;
+            case "redo":
+                chain.redo().run();
+                break;
+        }
+    }
+
+    private renderToolbarButton(
+        command: string,
+        icon: string,
+        title: string,
+        options?: Record<string, unknown>,
+    ) {
+        const isActive = this.activeFormats.has(command);
+        return html`
+            <button
+                type="button"
+                class="p-1.5 rounded transition-colors ${isActive
+                    ? "bg-gray-200 text-gray-900"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
+                title=${title}
+                @click=${() => this.exec(command, options)}
+            >
+                <span class="[&>svg]:w-4 [&>svg]:h-4 flex items-center justify-center">
+                    ${unsafeSVG(icon)}
+                </span>
+            </button>
+        `;
+    }
+
+    private renderSeparator() {
+        return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
+    }
+
+    private renderToolbar() {
+        if (this.compact) {
+            return html`
+                <div
+                    class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+                >
+                    <div class="flex items-center gap-0.5">
+                        ${this.renderToolbarButton("bold", Bold, "Bold")}
+                        ${this.renderToolbarButton("italic", Italic, "Italic")}
+                        ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
+                        ${this.renderSeparator()}
+                        ${this.renderToolbarButton("link", LinkIcon, "Link")}
+                    </div>
+                    <div class="flex-1"></div>
+                    ${this.renderSourceToggle()}
+                </div>
+            `;
+        }
+
+        return html`
+            <div
+                class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+            >
+                <div class="flex items-center gap-0.5">
+                    ${this.renderToolbarButton("bold", Bold, "Bold")}
+                    ${this.renderToolbarButton("italic", Italic, "Italic")}
+                    ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
+                    ${this.renderToolbarButton("strike", Strikethrough, "Strikethrough")}
+                    ${this.renderToolbarButton("code", Code, "Inline Code")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("h1", Heading1, "Heading 1")}
+                    ${this.renderToolbarButton("h2", Heading2, "Heading 2")}
+                    ${this.renderToolbarButton("h3", Heading3, "Heading 3")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("bulletList", List, "Bullet List")}
+                    ${this.renderToolbarButton("orderedList", ListOrdered, "Ordered List")}
+                    ${this.renderToolbarButton("blockquote", Quote, "Blockquote")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("link", LinkIcon, "Link")}
+                    ${this.renderToolbarButton("horizontalRule", Minus, "Horizontal Rule")}
+                    ${this.renderSeparator()}
+                    ${this.renderToolbarButton("undo", Undo2, "Undo")}
+                    ${this.renderToolbarButton("redo", Redo2, "Redo")}
+                </div>
+                <div class="flex-1"></div>
+                ${this.renderSourceToggle()}
+            </div>
+        `;
+    }
+
+    private renderSourceToggle() {
+        return html`
+            <button
+                type="button"
+                class="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${this
+                    .sourceMode
+                    ? "bg-gray-200 text-gray-900"
+                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
+                title=${this.sourceMode ? "Switch to rich text" : "View HTML source"}
+                @click=${this.toggleSourceMode}
+            >
+                <span class="[&>svg]:w-3.5 [&>svg]:h-3.5 flex items-center">
+                    ${unsafeSVG(Code2)}
+                </span>
+                ${this.sourceMode ? "Rich Text" : "Source"}
+            </button>
+        `;
+    }
+
+    render() {
+        return html`
+            <div class="editor-wrapper">
+                ${this.renderToolbar()}
+                <div id="editor" style=${this.sourceMode ? "display:none" : nothing}></div>
+                ${this.sourceMode
+                    ? html`
+                          <textarea
+                              class="source-textarea"
+                              .value=${this.sourceContent}
+                              @input=${this.handleSourceInput}
+                              spellcheck="false"
+                          ></textarea>
+                      `
+                    : nothing}
+            </div>
+        `;
+    }
+}
+
+declare global {
+    interface HTMLElementTagNameMap {
+        "scms-rich-text-editor": RichTextEditor;
+    }
+}

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -5,7 +5,7 @@
  * Mounts Tiptap directly on the page element being edited, providing
  * inline rich text formatting with clean HTML output.
  * Positioned fixed at the top of the viewport with a detached/hovering look.
- * Supports full and compact toolbar modes, and is draggable.
+ * Supports full and link toolbar modes, and is draggable.
  *
  * Uses custom schema extensions to prevent HTML normalization on load.
  * See src/extensions/tiptap-schema.ts for details.
@@ -38,6 +38,8 @@ import {
     ListOrdered,
     Quote,
     Link as LinkIcon,
+    ExternalLink,
+    Pilcrow,
     Minus,
     Undo2,
     Redo2,
@@ -47,7 +49,7 @@ import {
 @customElement("scms-formatting-toolbar")
 export class FormattingToolbar extends ScmsElement {
     @property({ type: Boolean })
-    compact = false;
+    linkMode = false;
 
     @state()
     private activeFormats: Set<string> = new Set();
@@ -130,8 +132,8 @@ export class FormattingToolbar extends ScmsElement {
      * Reuses existing editor for the same element (preserves undo history).
      * Creates a new editor for new elements without destroying others.
      */
-    attach(element: HTMLElement, compact: boolean): void {
-        this.compact = compact;
+    attach(element: HTMLElement, linkMode: boolean): void {
+        this.linkMode = linkMode;
         this.targetElement = element;
 
         // Reuse existing editor for this element
@@ -287,6 +289,7 @@ export class FormattingToolbar extends ScmsElement {
         if (this.editor.isActive("heading", { level: 1 })) formats.add("h1");
         if (this.editor.isActive("heading", { level: 2 })) formats.add("h2");
         if (this.editor.isActive("heading", { level: 3 })) formats.add("h3");
+        if (this.editor.isActive("paragraph")) formats.add("paragraph");
         if (this.editor.isActive("bulletList")) formats.add("bulletList");
         if (this.editor.isActive("orderedList")) formats.add("orderedList");
         if (this.editor.isActive("blockquote")) formats.add("blockquote");
@@ -342,13 +345,32 @@ export class FormattingToolbar extends ScmsElement {
                 chain.toggleCode().run();
                 break;
             case "h1":
-                chain.toggleHeading({ level: 1 }).run();
+                if (this.editor.isActive("heading", { level: 1 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 1 }).run();
+                }
                 break;
             case "h2":
-                chain.toggleHeading({ level: 2 }).run();
+                if (this.editor.isActive("heading", { level: 2 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 2 }).run();
+                }
                 break;
             case "h3":
-                chain.toggleHeading({ level: 3 }).run();
+                if (this.editor.isActive("heading", { level: 3 })) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setHeading({ level: 3 }).run();
+                }
+                break;
+            case "paragraph":
+                if (this.editor.isActive("paragraph")) {
+                    chain.setNode("spanParagraph").run();
+                } else {
+                    chain.setNode("paragraph").run();
+                }
                 break;
             case "bulletList":
                 chain.toggleBulletList().run();
@@ -379,6 +401,11 @@ export class FormattingToolbar extends ScmsElement {
                 }
                 break;
             }
+            case "goToLink":
+                if (this.targetElement instanceof HTMLAnchorElement) {
+                    window.open(this.targetElement.href, "_blank");
+                }
+                return;
             case "undo":
                 chain.undo().run();
                 break;
@@ -440,10 +467,11 @@ export class FormattingToolbar extends ScmsElement {
                 ${this.renderButton("strike", Strikethrough, "Strikethrough")}
                 ${this.renderButton("code", Code, "Inline Code")}
                 ${this.renderSeparator()}
+                ${this.renderButton("paragraph", Pilcrow, "Paragraph")}
                 ${this.renderButton("h1", Heading1, "Heading 1")}
                 ${this.renderButton("h2", Heading2, "Heading 2")}
                 ${this.renderButton("h3", Heading3, "Heading 3")}
-                ${this.compact
+                ${this.linkMode
                     ? nothing
                     : html`
                           ${this.renderSeparator()}
@@ -451,9 +479,11 @@ export class FormattingToolbar extends ScmsElement {
                           ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
                           ${this.renderButton("blockquote", Quote, "Blockquote")}
                       `}
-                ${this.compact ? nothing : this.renderSeparator()}
-                ${this.compact ? nothing : this.renderButton("link", LinkIcon, "Link")}
-                ${this.compact ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.linkMode ? nothing : this.renderSeparator()}
+                ${this.linkMode ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                ${this.linkMode ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.linkMode ? this.renderSeparator() : nothing}
+                ${this.linkMode ? this.renderButton("goToLink", ExternalLink, "Go to Link") : nothing}
                 ${this.renderSeparator()}
                 ${this.renderButton("undo", Undo2, "Undo")}
                 ${this.renderButton("redo", Redo2, "Redo")}

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -24,6 +24,7 @@ import {
     ListParagraph,
     FlexListItem,
     FlexBlockquote,
+    ParagraphSplitBlock,
 } from "../extensions/tiptap-schema.js";
 import {
     Bold,
@@ -209,6 +210,7 @@ export class FormattingToolbar extends ScmsElement {
                 ListParagraph,
                 FlexListItem,
                 FlexBlockquote,
+                ParagraphSplitBlock,
                 Link.configure({
                     openOnClick: false,
                     HTMLAttributes: { rel: null, target: null },

--- a/src/components/rich-text-editor.ts
+++ b/src/components/rich-text-editor.ts
@@ -1,9 +1,14 @@
 /**
- * Rich Text Editor Component
+ * Formatting Toolbar Component
  *
- * A shared WYSIWYG editor built on Tiptap (ProseMirror).
- * Used by both the HTML editor modal and link editor modal.
- * Supports full and compact toolbar modes, plus a raw HTML source toggle.
+ * A floating WYSIWYG formatting toolbar powered by Tiptap (ProseMirror).
+ * Mounts Tiptap directly on the page element being edited, providing
+ * inline rich text formatting with clean HTML output.
+ * Positioned fixed at the top of the viewport with a detached/hovering look.
+ * Supports full and compact toolbar modes, and is draggable.
+ *
+ * Uses custom schema extensions to prevent HTML normalization on load.
+ * See src/extensions/tiptap-schema.ts for details.
  */
 
 import { html, css, nothing } from "lit";
@@ -13,7 +18,13 @@ import { ScmsElement } from "./base.js";
 import { Editor } from "@tiptap/core";
 import StarterKit from "@tiptap/starter-kit";
 import Link from "@tiptap/extension-link";
-import Underline from "@tiptap/extension-underline";
+import {
+    SpanParagraph,
+    FlexDocument,
+    ListParagraph,
+    FlexListItem,
+    FlexBlockquote,
+} from "../extensions/tiptap-schema.js";
 import {
     Bold,
     Italic,
@@ -30,156 +41,82 @@ import {
     Minus,
     Undo2,
     Redo2,
-    Code2,
+    GripHorizontal,
 } from "lucide-static";
 
-@customElement("scms-rich-text-editor")
-export class RichTextEditor extends ScmsElement {
-    @property({ type: String })
-    content = "";
-
+@customElement("scms-formatting-toolbar")
+export class FormattingToolbar extends ScmsElement {
     @property({ type: Boolean })
     compact = false;
 
     @state()
-    private sourceMode = false;
-
-    @state()
-    private sourceContent = "";
-
-    @state()
     private activeFormats: Set<string> = new Set();
 
-    private editor: Editor | null = null;
+    @state()
+    private posX = -1;
+
+    @state()
+    private posY = 12;
+
+    /** The Tiptap editor for the currently active element. */
+    editor: Editor | null = null;
+
+    /** The element currently being edited. */
+    targetElement: HTMLElement | null = null;
+
+    /** The HTML at the time the current editor was created, for change detection. */
     private initialHTML = "";
+
+    /** All active editors, keyed by element. Preserved across blur/focus for undo history. */
+    editors: Map<HTMLElement, { editor: Editor; initialHTML: string }> = new Map();
+
+    private dragStartX = 0;
+    private dragStartY = 0;
+    private dragStartPosX = 0;
+    private dragStartPosY = 0;
+    /**
+     * Callback fired on each content update. Set by the controller
+     * to sync content changes back to the content manager.
+     */
+    onContentUpdate: (() => void) | null = null;
 
     static styles = [
         ...ScmsElement.styles,
         css`
-            .editor-wrapper {
-                border: 1px solid #d1d5db;
-                border-radius: 0.375rem;
-                overflow: hidden;
-            }
-
-            .editor-wrapper:focus-within {
-                border-color: #9ca3af;
-                box-shadow: 0 0 0 1px #9ca3af;
-            }
-
-            .ProseMirror {
-                outline: none;
-                padding: 0.75rem;
-                font-size: 14px;
-                line-height: 1.6;
-            }
-
-            :host([compact]) .ProseMirror {
-                min-height: 80px;
-                max-height: 200px;
-                overflow-y: auto;
-            }
-
-            :host(:not([compact])) .ProseMirror {
-                min-height: 200px;
-                max-height: 50vh;
-                overflow-y: auto;
-            }
-
-            .ProseMirror p {
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror h1 {
-                font-size: 1.5em;
-                font-weight: 700;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror h2 {
-                font-size: 1.25em;
-                font-weight: 600;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror h3 {
-                font-size: 1.1em;
-                font-weight: 600;
-                margin: 0.5em 0 0.25em;
-            }
-
-            .ProseMirror ul {
-                list-style: disc;
-                padding-left: 1.5em;
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror ol {
-                list-style: decimal;
-                padding-left: 1.5em;
-                margin: 0.25em 0;
-            }
-
-            .ProseMirror li {
-                margin: 0.1em 0;
-            }
-
-            .ProseMirror blockquote {
-                border-left: 3px solid #d1d5db;
-                padding-left: 1em;
-                color: #6b7280;
-                margin: 0.5em 0;
-            }
-
-            .ProseMirror a {
-                color: #2563eb;
-                text-decoration: underline;
-            }
-
-            .ProseMirror code {
-                background: #f3f4f6;
-                padding: 0.15em 0.35em;
-                border-radius: 0.25em;
-                font-size: 0.875em;
-                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-                    monospace;
-            }
-
-            .ProseMirror hr {
-                border: none;
-                border-top: 1px solid #d1d5db;
-                margin: 1em 0;
-            }
-
-            .ProseMirror p.is-editor-empty:first-child::before {
-                content: attr(data-placeholder);
-                color: #9ca3af;
+            :host {
+                position: fixed;
+                z-index: 10000;
+                display: block;
                 pointer-events: none;
-                float: left;
-                height: 0;
             }
 
-            .source-textarea {
-                font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
-                    monospace;
-                font-size: 13px;
-                line-height: 1.5;
-                tab-size: 2;
-                padding: 0.75rem;
-                width: 100%;
-                border: none;
-                outline: none;
-                resize: none;
+            .toolbar-container {
+                pointer-events: auto;
+                display: inline-flex;
+                align-items: center;
+                gap: 2px;
+                padding: 4px 8px;
+                background: white;
+                border: 1px solid #e5e7eb;
+                border-radius: 8px;
+                box-shadow:
+                    0 4px 6px -1px rgba(0, 0, 0, 0.1),
+                    0 2px 4px -2px rgba(0, 0, 0, 0.1);
+                flex-wrap: wrap;
             }
 
-            :host([compact]) .source-textarea {
-                min-height: 80px;
-                max-height: 200px;
+            .drag-handle {
+                cursor: grab;
+                padding: 4px 2px;
+                color: #9ca3af;
+                display: flex;
+                align-items: center;
+                user-select: none;
+                -webkit-user-select: none;
             }
 
-            :host(:not([compact])) .source-textarea {
-                min-height: 200px;
-                max-height: 50vh;
+            .drag-handle:active {
+                cursor: grabbing;
             }
 
             button {
@@ -188,80 +125,154 @@ export class RichTextEditor extends ScmsElement {
         `,
     ];
 
-    firstUpdated() {
-        const editorElement = this.shadowRoot!.querySelector("#editor") as HTMLElement;
-        if (!editorElement) return;
+    /**
+     * Attach Tiptap to a page element and show the toolbar.
+     * Reuses existing editor for the same element (preserves undo history).
+     * Creates a new editor for new elements without destroying others.
+     */
+    attach(element: HTMLElement, compact: boolean): void {
+        this.compact = compact;
+        this.targetElement = element;
 
+        // Reuse existing editor for this element
+        const existing = this.editors.get(element);
+        if (existing) {
+            this.editor = existing.editor;
+            this.initialHTML = existing.initialHTML;
+            this.editor.commands.focus();
+            this.updateActiveFormats();
+            this.style.display = "block";
+            return;
+        }
+
+        // Create new editor
         this.editor = new Editor({
-            element: editorElement,
+            element: { mount: element },
+            content: element.innerHTML,
             extensions: [
                 StarterKit.configure({
-                    heading: this.compact ? false : { levels: [1, 2, 3] },
-                    bulletList: this.compact ? false : undefined,
-                    orderedList: this.compact ? false : undefined,
-                    blockquote: this.compact ? false : undefined,
-                    horizontalRule: this.compact ? false : undefined,
-                    strike: this.compact ? false : undefined,
-                    code: this.compact ? false : undefined,
+                    document: false,
+                    listItem: false,
+                    blockquote: false,
+                    trailingNode: false,
+                    link: false,
+                    heading: { levels: [1, 2, 3] },
                 }),
+                FlexDocument,
+                SpanParagraph,
+                ListParagraph,
+                FlexListItem,
+                FlexBlockquote,
                 Link.configure({
                     openOnClick: false,
-                    HTMLAttributes: {
-                        rel: null,
-                        target: null,
-                    },
+                    HTMLAttributes: { rel: null, target: null },
                 }),
-                Underline,
             ],
-            content: this.content,
-            onTransaction: () => {
+            onUpdate: () => {
                 this.updateActiveFormats();
-                this.dispatchEvent(
-                    new CustomEvent("content-change", {
-                        detail: { content: this.editor!.getHTML() },
-                        bubbles: true,
-                        composed: true,
-                    }),
-                );
+                this.onContentUpdate?.();
+            },
+            onSelectionUpdate: () => {
+                this.updateActiveFormats();
             },
         });
 
         this.initialHTML = this.editor.getHTML();
+        this.editors.set(element, { editor: this.editor, initialHTML: this.initialHTML });
+
+        // Center horizontally on first show
+        if (this.posX === -1) {
+            requestAnimationFrame(() => {
+                const toolbar = this.shadowRoot?.querySelector(
+                    ".toolbar-container",
+                ) as HTMLElement | null;
+                if (toolbar) {
+                    this.posX = Math.max(
+                        12,
+                        (window.innerWidth - toolbar.offsetWidth) / 2,
+                    );
+                }
+            });
+        }
+
         this.updateActiveFormats();
+        this.style.display = "block";
+    }
+
+    /**
+     * Whether the current editor's content has changed from when it was loaded.
+     */
+    hasChanges(): boolean {
+        if (!this.editor) return false;
+        return this.editor.getHTML() !== this.initialHTML;
+    }
+
+    /**
+     * Check if a specific element's editor has changes.
+     */
+    hasChangesFor(element: HTMLElement): boolean {
+        const entry = this.editors.get(element);
+        if (!entry) return false;
+        return entry.editor.getHTML() !== entry.initialHTML;
+    }
+
+    /**
+     * Destroy the editor for a specific element and restore its HTML.
+     */
+    detachElement(element: HTMLElement): void {
+        const entry = this.editors.get(element);
+        if (!entry) return;
+
+        const finalHTML = entry.editor.getHTML();
+        entry.editor.destroy();
+        this.editors.delete(element);
+        element.innerHTML = finalHTML;
+
+        // If this was the active element, clear current state
+        if (this.targetElement === element) {
+            this.editor = null;
+            this.targetElement = null;
+            this.activeFormats = new Set();
+            this.style.display = "none";
+        }
+    }
+
+    /**
+     * Destroy all editors and clean up.
+     */
+    detach(): void {
+        for (const [element, entry] of this.editors) {
+            const finalHTML = entry.editor.getHTML();
+            entry.editor.destroy();
+            element.innerHTML = finalHTML;
+        }
+        this.editors.clear();
+        this.editor = null;
+        this.targetElement = null;
+        this.activeFormats = new Set();
+        this.style.display = "none";
+    }
+
+    /**
+     * Get the current content as HTML.
+     */
+    getHTML(): string {
+        return this.editor?.getHTML() || "";
+    }
+
+    /**
+     * Programmatically set the editor content.
+     */
+    setContent(htmlContent: string): void {
+        if (this.editor) {
+            this.editor.commands.setContent(htmlContent, { emitUpdate: true });
+        }
     }
 
     disconnectedCallback() {
         super.disconnectedCallback();
-        this.editor?.destroy();
-        this.editor = null;
-    }
+        this.detach();
 
-    updated(changedProperties: Map<string, unknown>) {
-        if (changedProperties.has("content") && this.editor) {
-            const currentHTML = this.editor.getHTML();
-            if (currentHTML !== this.content) {
-                this.editor.commands.setContent(this.content, { emitUpdate: false });
-            }
-        }
-    }
-
-    /**
-     * Get the current editor content as HTML
-     */
-    getHTML(): string {
-        if (this.sourceMode) {
-            return this.sourceContent;
-        }
-        return this.editor?.getHTML() || this.content;
-    }
-
-    /**
-     * Whether the editor content has changed from what was initially loaded.
-     * Compares against Tiptap-normalized HTML to avoid false positives from
-     * normalization (e.g. "Hello" → "<p>Hello</p>").
-     */
-    hasChanges(): boolean {
-        return this.getHTML() !== this.initialHTML;
     }
 
     private updateActiveFormats() {
@@ -284,33 +295,33 @@ export class RichTextEditor extends ScmsElement {
         this.activeFormats = formats;
     }
 
-    private toggleSourceMode() {
-        if (this.sourceMode) {
-            // Switching back to rich text: apply source content to editor
-            if (this.editor) {
-                this.editor.commands.setContent(this.sourceContent, { emitUpdate: false });
-            }
-            this.sourceMode = false;
-        } else {
-            // Switching to source: capture editor HTML
-            this.sourceContent = this.editor?.getHTML() || this.content;
-            this.sourceMode = true;
-        }
+    // --- Drag handling ---
+
+    private handleDragStart(e: PointerEvent) {
+        this.dragStartX = e.clientX;
+        this.dragStartY = e.clientY;
+        this.dragStartPosX = this.posX;
+        this.dragStartPosY = this.posY;
+
+        const onMove = (ev: PointerEvent) => {
+            const dx = ev.clientX - this.dragStartX;
+            const dy = ev.clientY - this.dragStartY;
+            this.posX = Math.max(0, this.dragStartPosX + dx);
+            this.posY = Math.max(0, this.dragStartPosY + dy);
+        };
+
+        const onUp = () => {
+            window.removeEventListener("pointermove", onMove);
+            window.removeEventListener("pointerup", onUp);
+        };
+
+        window.addEventListener("pointermove", onMove);
+        window.addEventListener("pointerup", onUp);
     }
 
-    private handleSourceInput(e: Event) {
-        const textarea = e.target as HTMLTextAreaElement;
-        this.sourceContent = textarea.value;
-        this.dispatchEvent(
-            new CustomEvent("content-change", {
-                detail: { content: this.sourceContent },
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    }
+    // --- Command execution ---
 
-    private exec(command: string, options?: Record<string, unknown>) {
+    private exec(command: string) {
         if (!this.editor) return;
         const chain = this.editor.chain().focus();
 
@@ -352,14 +363,19 @@ export class RichTextEditor extends ScmsElement {
                 chain.setHorizontalRule().run();
                 break;
             case "link": {
-                if (this.editor.isActive("link")) {
+                const currentHref = this.editor.getAttributes("link").href || "";
+                const message = currentHref
+                    ? "Edit URL (clear to remove link):"
+                    : "Enter URL:";
+                const href = prompt(message, currentHref);
+                if (href === null) {
+                    // User cancelled — do nothing
+                } else if (href === "") {
+                    // Empty input — remove link
                     chain.unsetLink().run();
                 } else {
-                    const url = options?.href as string | undefined;
-                    const href = url || prompt("Enter URL:");
-                    if (href) {
-                        chain.setLink({ href }).run();
-                    }
+                    // Set or update link
+                    chain.setLink({ href }).run();
                 }
                 break;
             }
@@ -372,12 +388,9 @@ export class RichTextEditor extends ScmsElement {
         }
     }
 
-    private renderToolbarButton(
-        command: string,
-        icon: string,
-        title: string,
-        options?: Record<string, unknown>,
-    ) {
+    // --- Rendering ---
+
+    private renderButton(command: string, icon: string, title: string) {
         const isActive = this.activeFormats.has(command);
         return html`
             <button
@@ -386,7 +399,8 @@ export class RichTextEditor extends ScmsElement {
                     ? "bg-gray-200 text-gray-900"
                     : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
                 title=${title}
-                @click=${() => this.exec(command, options)}
+                @mousedown=${(e: Event) => e.preventDefault()}
+                @click=${() => this.exec(command)}
             >
                 <span class="[&>svg]:w-4 [&>svg]:h-4 flex items-center justify-center">
                     ${unsafeSVG(icon)}
@@ -399,90 +413,50 @@ export class RichTextEditor extends ScmsElement {
         return html`<span class="w-px h-5 bg-gray-200 mx-0.5"></span>`;
     }
 
-    private renderToolbar() {
-        if (this.compact) {
-            return html`
-                <div
-                    class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
-                >
-                    <div class="flex items-center gap-0.5">
-                        ${this.renderToolbarButton("bold", Bold, "Bold")}
-                        ${this.renderToolbarButton("italic", Italic, "Italic")}
-                        ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
-                        ${this.renderSeparator()}
-                        ${this.renderToolbarButton("link", LinkIcon, "Link")}
-                    </div>
-                    <div class="flex-1"></div>
-                    ${this.renderSourceToggle()}
-                </div>
-            `;
-        }
+    render() {
+        if (!this.editor) return nothing;
+
+        const left = this.posX === -1 ? "50%" : `${this.posX}px`;
+        const transform = this.posX === -1 ? "translateX(-50%)" : "none";
 
         return html`
             <div
-                class="flex items-center gap-0.5 px-2 py-1.5 border-b border-gray-200 bg-gray-50 flex-wrap"
+                class="toolbar-container"
+                style="position:fixed; top:${this.posY}px; left:${left}; transform:${transform};"
             >
-                <div class="flex items-center gap-0.5">
-                    ${this.renderToolbarButton("bold", Bold, "Bold")}
-                    ${this.renderToolbarButton("italic", Italic, "Italic")}
-                    ${this.renderToolbarButton("underline", UnderlineIcon, "Underline")}
-                    ${this.renderToolbarButton("strike", Strikethrough, "Strikethrough")}
-                    ${this.renderToolbarButton("code", Code, "Inline Code")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("h1", Heading1, "Heading 1")}
-                    ${this.renderToolbarButton("h2", Heading2, "Heading 2")}
-                    ${this.renderToolbarButton("h3", Heading3, "Heading 3")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("bulletList", List, "Bullet List")}
-                    ${this.renderToolbarButton("orderedList", ListOrdered, "Ordered List")}
-                    ${this.renderToolbarButton("blockquote", Quote, "Blockquote")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("link", LinkIcon, "Link")}
-                    ${this.renderToolbarButton("horizontalRule", Minus, "Horizontal Rule")}
-                    ${this.renderSeparator()}
-                    ${this.renderToolbarButton("undo", Undo2, "Undo")}
-                    ${this.renderToolbarButton("redo", Redo2, "Redo")}
+                <div
+                    class="drag-handle"
+                    @pointerdown=${this.handleDragStart}
+                    title="Drag to reposition"
+                >
+                    <span class="[&>svg]:w-4 [&>svg]:h-4">
+                        ${unsafeSVG(GripHorizontal)}
+                    </span>
                 </div>
-                <div class="flex-1"></div>
-                ${this.renderSourceToggle()}
-            </div>
-        `;
-    }
-
-    private renderSourceToggle() {
-        return html`
-            <button
-                type="button"
-                class="flex items-center gap-1 px-2 py-1 text-xs font-medium rounded transition-colors ${this
-                    .sourceMode
-                    ? "bg-gray-200 text-gray-900"
-                    : "text-gray-500 hover:text-gray-700 hover:bg-gray-100"}"
-                title=${this.sourceMode ? "Switch to rich text" : "View HTML source"}
-                @click=${this.toggleSourceMode}
-            >
-                <span class="[&>svg]:w-3.5 [&>svg]:h-3.5 flex items-center">
-                    ${unsafeSVG(Code2)}
-                </span>
-                ${this.sourceMode ? "Rich Text" : "Source"}
-            </button>
-        `;
-    }
-
-    render() {
-        return html`
-            <div class="editor-wrapper">
-                ${this.renderToolbar()}
-                <div id="editor" style=${this.sourceMode ? "display:none" : nothing}></div>
-                ${this.sourceMode
-                    ? html`
-                          <textarea
-                              class="source-textarea"
-                              .value=${this.sourceContent}
-                              @input=${this.handleSourceInput}
-                              spellcheck="false"
-                          ></textarea>
-                      `
-                    : nothing}
+                ${this.renderSeparator()}
+                ${this.renderButton("bold", Bold, "Bold")}
+                ${this.renderButton("italic", Italic, "Italic")}
+                ${this.renderButton("underline", UnderlineIcon, "Underline")}
+                ${this.renderButton("strike", Strikethrough, "Strikethrough")}
+                ${this.renderButton("code", Code, "Inline Code")}
+                ${this.renderSeparator()}
+                ${this.renderButton("h1", Heading1, "Heading 1")}
+                ${this.renderButton("h2", Heading2, "Heading 2")}
+                ${this.renderButton("h3", Heading3, "Heading 3")}
+                ${this.compact
+                    ? nothing
+                    : html`
+                          ${this.renderSeparator()}
+                          ${this.renderButton("bulletList", List, "Bullet List")}
+                          ${this.renderButton("orderedList", ListOrdered, "Ordered List")}
+                          ${this.renderButton("blockquote", Quote, "Blockquote")}
+                      `}
+                ${this.compact ? nothing : this.renderSeparator()}
+                ${this.compact ? nothing : this.renderButton("link", LinkIcon, "Link")}
+                ${this.compact ? nothing : this.renderButton("horizontalRule", Minus, "Horizontal Rule")}
+                ${this.renderSeparator()}
+                ${this.renderButton("undo", Undo2, "Undo")}
+                ${this.renderButton("redo", Redo2, "Redo")}
             </div>
         `;
     }
@@ -490,6 +464,6 @@ export class RichTextEditor extends ScmsElement {
 
 declare global {
     interface HTMLElementTagNameMap {
-        "scms-rich-text-editor": RichTextEditor;
+        "scms-formatting-toolbar": FormattingToolbar;
     }
 }

--- a/src/components/seo-modal.ts
+++ b/src/components/seo-modal.ts
@@ -309,14 +309,7 @@ export class SeoModal extends ScmsElement {
             >
                 <!-- Header -->
                 <div class="px-4 py-3 border-b border-gray-200 flex items-center justify-between">
-                    <div class="flex items-center gap-2">
-                        <span class="text-sm font-medium text-gray-900">SEO Attributes</span>
-                        <span
-                            class="text-xs font-mono text-gray-500 bg-gray-100 px-2 py-0.5 rounded"
-                        >
-                            ${this.elementId}
-                        </span>
-                    </div>
+                    <span class="text-sm font-medium text-gray-900">SEO Attributes</span>
                     <button
                         class="text-gray-400 hover:text-gray-600 p-1"
                         @click=${this.handleCancel}

--- a/src/components/seo-modal.ts
+++ b/src/components/seo-modal.ts
@@ -29,12 +29,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "primary",
             link: "not-applicable",
+            href: "not-applicable",
             text: "not-applicable",
             html: "not-applicable",
         },
         tips: {
             image: "Describe the image for screen readers and when the image fails to load. Be concise but descriptive.",
             link: "Alt text is typically used for images, not links.",
+            href: "Alt text is typically used for images, not links.",
             text: "Alt text is typically used for images, not text elements.",
             html: "Alt text is typically used for images, not HTML elements.",
         },
@@ -47,12 +49,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "secondary",
             link: "secondary",
+            href: "secondary",
             text: "secondary",
             html: "secondary",
         },
         tips: {
             image: "Shows as a tooltip on hover. Generally not needed if alt text is good.",
             link: "Shows as a tooltip on hover. Can provide additional context about the link destination.",
+            href: "Shows as a tooltip on hover. Can provide additional context about the link destination.",
             text: "Shows as a tooltip on hover. Rarely needed for text elements.",
             html: "Shows as a tooltip on hover. Rarely needed for HTML elements.",
         },
@@ -72,12 +76,14 @@ const SEO_FIELDS: FieldConfig[] = [
         priority: {
             image: "not-applicable",
             link: "primary",
+            href: "primary",
             text: "not-applicable",
             html: "not-applicable",
         },
         tips: {
             image: "Link relationship is typically used for anchor elements, not images.",
             link: "Controls how search engines treat this link and security for external links.",
+            href: "Controls how search engines treat this link and security for external links.",
             text: "Link relationship is typically used for anchor elements, not text.",
             html: "Link relationship is typically used for anchor elements, not HTML elements.",
         },

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -6,7 +6,7 @@
  * - Mobile: collapses secondary actions into expandable drawer
  *
  * Primary actions (always visible): Save, Reset
- * Secondary actions (collapsible on mobile): Mode toggle, Edit Content, Sign Out
+ * Secondary actions (collapsible on mobile): Mode toggle, View Source, Sign Out
  */
 
 import { html, css, nothing } from "lit";
@@ -453,15 +453,15 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderEditHtmlButton() {
-        // Show only for html type (not for text, image, or link)
-        if (!this.activeElement || this.activeElementType !== "html") return nothing;
+        // Show for html and link types (not for text or image)
+        if (!this.activeElement || (this.activeElementType !== "html" && this.activeElementType !== "link")) return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
                 data-action="edit-html"
                 @click=${this.handleEditHtml}
             >
-                Edit Content
+                View Source
             </button>
         `;
     }
@@ -871,14 +871,14 @@ export class Toolbar extends ScmsElement {
                 `;
             }
 
-            if (this.activeElementType === "html") {
+            if (this.activeElementType === "html" || this.activeElementType === "link") {
                 return html`
                     <button
                         class="w-full px-3 py-2 text-sm font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-white transition-colors"
                         data-action="edit-html"
                         @click=${this.handleEditHtml}
                     >
-                        Edit Content
+                        View Source
                     </button>
                 `;
             }

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -445,7 +445,11 @@ export class Toolbar extends ScmsElement {
 
     private renderEditHtmlButton() {
         // Show for html and link types (not for text or image)
-        if (!this.activeElement || (this.activeElementType !== "html" && this.activeElementType !== "link")) return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "html" && this.activeElementType !== "link")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -6,7 +6,7 @@
  * - Mobile: collapses secondary actions into expandable drawer
  *
  * Primary actions (always visible): Save, Reset
- * Secondary actions (collapsible on mobile): Mode toggle, Edit HTML, Sign Out
+ * Secondary actions (collapsible on mobile): Mode toggle, Edit Content, Sign Out
  */
 
 import { html, css, nothing } from "lit";
@@ -461,7 +461,7 @@ export class Toolbar extends ScmsElement {
                 data-action="edit-html"
                 @click=${this.handleEditHtml}
             >
-                Edit HTML
+                Edit Content
             </button>
         `;
     }
@@ -878,7 +878,7 @@ export class Toolbar extends ScmsElement {
                         data-action="edit-html"
                         @click=${this.handleEditHtml}
                     >
-                        Edit HTML
+                        Edit Content
                     </button>
                 `;
             }

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -475,7 +475,11 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderEditLinkButton() {
-        if (!this.activeElement || this.activeElementType !== "link") return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "link" && this.activeElementType !== "href")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-gray-600 hover:text-gray-800 border border-gray-300 rounded-md hover:bg-gray-50 transition-colors"
@@ -488,7 +492,11 @@ export class Toolbar extends ScmsElement {
     }
 
     private renderGoToLinkButton() {
-        if (!this.activeElement || this.activeElementType !== "link") return nothing;
+        if (
+            !this.activeElement ||
+            (this.activeElementType !== "link" && this.activeElementType !== "href")
+        )
+            return nothing;
         return html`
             <button
                 class="px-3 py-1.5 text-xs font-medium text-blue-600 hover:text-blue-800 border border-blue-300 rounded-md hover:bg-blue-50 transition-colors inline-flex items-center gap-1"

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -17,6 +17,7 @@ import {
     ChevronUp,
     ChevronDown,
     Ellipsis,
+    Expand,
     Layers,
     Plus,
     ScanEye,
@@ -85,6 +86,9 @@ export class Toolbar extends ScmsElement {
 
     @property({ type: Boolean, attribute: "content-viewer-active" })
     contentViewerActive = false;
+
+    @property({ type: Boolean, attribute: "has-outer-editable" })
+    hasOuterEditable = false;
 
     @property({ type: Number, attribute: "hidden-element-count" })
     hiddenElementCount = 0;
@@ -382,6 +386,15 @@ export class Toolbar extends ScmsElement {
         );
     }
 
+    private handleSelectOuter() {
+        this.dispatchEvent(
+            new CustomEvent("select-outer", {
+                bubbles: true,
+                composed: true,
+            }),
+        );
+    }
+
     private handleShowHiddenElements(e: Event) {
         e.stopPropagation();
         this.dispatchEvent(
@@ -655,6 +668,22 @@ export class Toolbar extends ScmsElement {
         `;
     }
 
+    private renderSelectOuterButton() {
+        if (this.warning || this.readOnly) return nothing;
+        if (!this.hasOuterEditable) return nothing;
+        return html`
+            <button
+                class="w-8 h-8 flex items-center justify-center text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-full transition-colors [&>svg]:w-5 [&>svg]:h-5"
+                data-action="select-outer"
+                @click=${this.handleSelectOuter}
+                title="Select outer element"
+                aria-label="Select outer element"
+            >
+                ${unsafeSVG(Expand)}
+            </button>
+        `;
+    }
+
     private renderContentViewerButton() {
         // Only show in editing mode (not viewer or when warning/readOnly)
         if (this.warning || this.readOnly) return nothing;
@@ -774,7 +803,8 @@ export class Toolbar extends ScmsElement {
 
                     <!-- Right: Undo + Content Viewer + Save + Sign Out + Admin + Help -->
                     <div class="flex items-center">
-                        ${this.renderUndoButton()} ${this.renderContentViewerButton()}
+                        ${this.renderUndoButton()} ${this.renderSelectOuterButton()}
+                        ${this.renderContentViewerButton()}
                         ${this.hasChanges
                             ? html`<span class="mx-3">${this.renderSaveButton()}</span>`
                             : nothing}
@@ -1175,7 +1205,8 @@ export class Toolbar extends ScmsElement {
                         class="flex items-center w-20 justify-end gap-1"
                         @click=${(e: Event) => e.stopPropagation()}
                     >
-                        ${this.renderContentViewerButton()} ${this.renderHelpButton()}
+                        ${this.renderSelectOuterButton()} ${this.renderContentViewerButton()}
+                        ${this.renderHelpButton()}
                     </div>
                 </button>
 

--- a/src/components/toolbar.ts
+++ b/src/components/toolbar.ts
@@ -292,15 +292,6 @@ export class Toolbar extends ScmsElement {
         );
     }
 
-    private handleRedo() {
-        this.dispatchEvent(
-            new CustomEvent("redo", {
-                bubbles: true,
-                composed: true,
-            }),
-        );
-    }
-
     private handleEditHtml() {
         this.dispatchEvent(
             new CustomEvent("edit-html", {

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -201,9 +201,7 @@ export const ParagraphSplitBlock = Extension.create({
                     deflt = getDefault();
 
                     let types =
-                        atEnd && deflt
-                            ? [{ type: deflt, attrs: $from.node().attrs }]
-                            : undefined;
+                        atEnd && deflt ? [{ type: deflt, attrs: $from.node().attrs }] : undefined;
 
                     let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types);
 

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -18,7 +18,9 @@
  *   - "<blockquote>text</bq>"   → <bq><span>text</span></bq>(no visual change)
  */
 
-import { Node, mergeAttributes } from "@tiptap/core";
+import { Extension, Node, mergeAttributes } from "@tiptap/core";
+import { NodeSelection, TextSelection } from "@tiptap/pm/state";
+import { canSplit } from "@tiptap/pm/transform";
 
 /**
  * A block node that renders as <span> instead of <p>.
@@ -127,4 +129,129 @@ export const InlineDocument = Node.create({
     name: "doc",
     topNode: true,
     content: "inline*",
+});
+
+/**
+ * Overrides Tiptap's default splitBlock command so pressing Enter creates a
+ * <p> instead of a <span>. The schema lists spanParagraph first (so bare text
+ * loads without <p> wrapping), but ProseMirror's defaultBlockAt picks the
+ * first textblock from the parent's content match — which is spanParagraph.
+ *
+ * This extension replaces splitBlock with a copy of Tiptap's implementation
+ * that forces the new node type to "paragraph" when available, falling back
+ * to defaultBlockAt otherwise. List item splitting is unaffected (it has its
+ * own splitListItem command).
+ */
+export const ParagraphSplitBlock = Extension.create({
+    name: "paragraphSplitBlock",
+
+    addCommands() {
+        return {
+            splitBlock:
+                ({ keepMarks = true } = {}) =>
+                ({ tr, state, dispatch, editor }) => {
+                    const { selection, doc } = tr;
+                    const { $from, $to } = selection;
+
+                    const ensureMarks = () => {
+                        const marks =
+                            state.storedMarks ||
+                            (state.selection.$to.parentOffset && state.selection.$from.marks());
+                        if (marks) {
+                            const splittable = editor.extensionManager.splittableMarks;
+                            const filtered = marks.filter((m) => splittable?.includes(m.type.name));
+                            state.tr.ensureMarks(filtered);
+                        }
+                    };
+
+                    if (selection instanceof NodeSelection && selection.node.isBlock) {
+                        if (!$from.parentOffset || !canSplit(doc, $from.pos)) {
+                            return false;
+                        }
+                        if (dispatch) {
+                            if (keepMarks) ensureMarks();
+                            tr.split($from.pos).scrollIntoView();
+                        }
+                        return true;
+                    }
+
+                    if (!$from.parent.isBlock) return false;
+
+                    const atEnd = $to.parentOffset === $to.parent.content.size;
+
+                    // Pick the new block type: prefer "paragraph" if it's a valid
+                    // child of the parent at this position; otherwise fall back to
+                    // the parent's default textblock.
+                    let deflt = undefined as ReturnType<typeof getDefault>;
+                    function getDefault() {
+                        if ($from.depth === 0) return undefined;
+                        const match = $from.node(-1).contentMatchAt($from.indexAfter(-1));
+                        const paragraphType = editor.schema.nodes.paragraph;
+                        if (paragraphType && match.matchType(paragraphType)) {
+                            return paragraphType;
+                        }
+                        for (let i = 0; i < match.edgeCount; i += 1) {
+                            const { type } = match.edge(i);
+                            if (type.isTextblock && !type.hasRequiredAttrs()) {
+                                return type;
+                            }
+                        }
+                        return undefined;
+                    }
+                    deflt = getDefault();
+
+                    let types =
+                        atEnd && deflt
+                            ? [{ type: deflt, attrs: $from.node().attrs }]
+                            : undefined;
+
+                    let can = canSplit(tr.doc, tr.mapping.map($from.pos), 1, types);
+
+                    if (
+                        !types &&
+                        !can &&
+                        canSplit(
+                            tr.doc,
+                            tr.mapping.map($from.pos),
+                            1,
+                            deflt ? [{ type: deflt }] : undefined,
+                        )
+                    ) {
+                        can = true;
+                        types = deflt ? [{ type: deflt, attrs: $from.node().attrs }] : undefined;
+                    }
+
+                    if (dispatch) {
+                        if (can) {
+                            if (selection instanceof TextSelection) {
+                                tr.deleteSelection();
+                            }
+                            tr.split(tr.mapping.map($from.pos), 1, types);
+
+                            if (
+                                deflt &&
+                                !atEnd &&
+                                !$from.parentOffset &&
+                                $from.parent.type !== deflt
+                            ) {
+                                const first = tr.mapping.map($from.before());
+                                const $first = tr.doc.resolve(first);
+                                if (
+                                    $from
+                                        .node(-1)
+                                        .canReplaceWith($first.index(), $first.index() + 1, deflt)
+                                ) {
+                                    tr.setNodeMarkup(tr.mapping.map($from.before()), deflt);
+                                }
+                            }
+                        }
+
+                        if (keepMarks) ensureMarks();
+                        tr.scrollIntoView();
+                    }
+
+                    return can;
+                },
+        };
+    },
 });

--- a/src/extensions/tiptap-schema.ts
+++ b/src/extensions/tiptap-schema.ts
@@ -1,0 +1,130 @@
+/**
+ * Custom Tiptap Schema Extensions
+ *
+ * ProseMirror requires block nodes as children of Document, ListItem, and
+ * Blockquote. By default, bare inline content gets wrapped in a <p> tag,
+ * causing unwanted visual changes when the editor loads.
+ *
+ * These extensions solve this by defining a "spanParagraph" node that renders
+ * as <span> instead of <p>. It is placed first in content expressions so
+ * ProseMirror uses it as the default wrapper for bare text. The standard
+ * Paragraph node (renders <p>) is preserved for content that already has
+ * <p> tags — those parse into "paragraph" and round-trip cleanly.
+ *
+ * Result:
+ *   - "bare text"               → <span>bare text</span>    (no visual change)
+ *   - "<p>paragraph</p>"        → <p>paragraph</p>          (preserved)
+ *   - "<li>item</li>"           → <li><span>item</span></li>(no visual change)
+ *   - "<blockquote>text</bq>"   → <bq><span>text</span></bq>(no visual change)
+ */
+
+import { Node, mergeAttributes } from "@tiptap/core";
+
+/**
+ * A block node that renders as <span> instead of <p>.
+ * Used as the default wrapper for bare inline content, avoiding the visual
+ * impact of <p> tags (margins, line breaks). Never parsed from HTML — it
+ * is only created by ProseMirror when it needs to wrap bare text.
+ */
+export const SpanParagraph = Node.create({
+    name: "spanParagraph",
+
+    content: "inline*",
+
+    group: "block",
+
+    parseHTML() {
+        return [];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["span", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+/**
+ * Document node that prefers spanParagraph as the default wrapper.
+ * By listing spanParagraph first, ProseMirror uses it (instead of <p>)
+ * when bare text needs a block wrapper.
+ */
+export const FlexDocument = Node.create({
+    name: "doc",
+    topNode: true,
+    content: "(spanParagraph | block)+",
+});
+
+/**
+ * ListItem that uses a span-rendering wrapper for its required first
+ * block child, instead of paragraph which renders as <p>.
+ */
+export const ListParagraph = Node.create({
+    name: "listParagraph",
+
+    content: "inline*",
+
+    group: "block",
+
+    parseHTML() {
+        return [];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["span", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+export const FlexListItem = Node.create({
+    name: "listItem",
+
+    content: "(listParagraph | paragraph) block*",
+
+    defining: true,
+
+    parseHTML() {
+        return [{ tag: "li" }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["li", mergeAttributes(HTMLAttributes), 0];
+    },
+
+    addKeyboardShortcuts() {
+        return {
+            Enter: () => this.editor.commands.splitListItem(this.name),
+            Tab: () => this.editor.commands.sinkListItem(this.name),
+            "Shift-Tab": () => this.editor.commands.liftListItem(this.name),
+        };
+    },
+});
+
+/**
+ * Blockquote that prefers spanParagraph as the default wrapper,
+ * same pattern as FlexDocument.
+ */
+export const FlexBlockquote = Node.create({
+    name: "blockquote",
+
+    content: "(spanParagraph | block)+",
+
+    group: "block",
+
+    defining: true,
+
+    parseHTML() {
+        return [{ tag: "blockquote" }];
+    },
+
+    renderHTML({ HTMLAttributes }) {
+        return ["blockquote", mergeAttributes(HTMLAttributes), 0];
+    },
+});
+
+/**
+ * Inline-only document node for compact/link editing mode.
+ * Content is purely inline — no block wrappers at all.
+ */
+export const InlineDocument = Node.create({
+    name: "doc",
+    topNode: true,
+    content: "inline*",
+});

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -55,6 +55,36 @@ function readTextWithBreaks(element: HTMLElement): string {
     return (clone.textContent || "").replace(/\u00a0/g, " ");
 }
 
+/**
+ * Whether an editable element has no visible content. Used to toggle the
+ * "Click to edit" placeholder. Treats stray <br> tags (left behind by
+ * contenteditable when the last character is deleted) and Tiptap's empty
+ * `<p></p>` / `<p><br></p>` shells as empty.
+ */
+export function isVisuallyEmpty(element: HTMLElement): boolean {
+    for (const node of Array.from(element.childNodes)) {
+        if (node.nodeType === Node.TEXT_NODE) {
+            if ((node.textContent || "").replace(/\u00a0/g, " ").trim() !== "") {
+                return false;
+            }
+        } else if (node.nodeType === Node.ELEMENT_NODE) {
+            const el = node as HTMLElement;
+            if (el.tagName === "BR") continue;
+            if (el.tagName === "P" && isVisuallyEmpty(el)) continue;
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Toggle the `streamlined-empty` class so the placeholder rule in styles.ts
+ * matches when the element has no visible content.
+ */
+export function updateEmptyState(element: HTMLElement): void {
+    element.classList.toggle("streamlined-empty", isVisuallyEmpty(element));
+}
+
 function writeTextWithBreaks(element: HTMLElement, text: string): void {
     element.textContent = "";
     const parts = text.split("\n");
@@ -85,6 +115,10 @@ export class ContentManager {
 
         // Sync all other DOM elements from currentContent
         this.syncAllElementsFromContent(key, sourceElement);
+
+        // Refresh placeholder state for the element the user just typed in
+        // (sync handles the others via applyElementContent).
+        updateEmptyState(sourceElement);
     }
 
     /**
@@ -213,31 +247,29 @@ export class ContentManager {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
                         this.setElementHTML(info.element, linkData.value || "");
-                        return;
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
                     const imageData = data as { src?: string };
                     if (imageData.src !== undefined) {
                         info.element.src = imageData.src;
-                        return;
                     }
                 } else if (elementType === "text") {
                     const textData = data as { value?: string };
                     if (textData.value !== undefined) {
                         writeTextWithBreaks(info.element, textData.value);
-                        return;
                     }
                 } else if (elementType === "html") {
                     const htmlData = data as { value?: string };
                     if (htmlData.value !== undefined) {
                         this.setElementHTML(info.element, htmlData.value);
-                        return;
                     }
                 }
             }
         } catch {
             // Not JSON - ignore, content should always be JSON
         }
+
+        updateEmptyState(info.element);
     }
 
     /**

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -15,6 +15,7 @@ import type {
     HtmlContentData,
     ImageContentData,
     LinkContentData,
+    HrefContentData,
 } from "../types.js";
 import { applyAttributesToElement } from "../types.js";
 
@@ -85,6 +86,12 @@ export function isVisuallyEmpty(element: HTMLElement): boolean {
  * matches when the element has no visible content.
  */
 export function updateEmptyState(element: HTMLElement): void {
+    // href elements manage their own inner markup; the SDK doesn't own the
+    // content inside, so a "Click to edit" placeholder would be misleading.
+    if (element.hasAttribute("data-scms-href")) {
+        element.classList.remove("streamlined-empty");
+        return;
+    }
     element.classList.toggle("streamlined-empty", isVisuallyEmpty(element));
 }
 
@@ -183,6 +190,14 @@ export class ContentManager {
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
+        } else if (elementType === "href" && info.element instanceof HTMLAnchorElement) {
+            const data: HrefContentData = {
+                type: "href",
+                href: info.element.getAttribute("href") || "",
+                target: info.element.target,
+                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+            };
+            return JSON.stringify(data);
         } else if (elementType === "text") {
             const data: TextContentData = {
                 type: "text",
@@ -242,6 +257,10 @@ export class ContentManager {
                 info.element.href = linkData.href;
                 info.element.target = linkData.target;
                 this.setElementHTML(info.element, linkData.value);
+            } else if (data.type === "href" && info.element instanceof HTMLAnchorElement) {
+                const hrefData = data as HrefContentData;
+                info.element.href = hrefData.href;
+                info.element.target = hrefData.target;
             } else if (!data.type) {
                 // No type field in JSON - use element's declared type
                 if (elementType === "link" && info.element instanceof HTMLAnchorElement) {
@@ -250,6 +269,12 @@ export class ContentManager {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
                         this.setElementHTML(info.element, linkData.value || "");
+                    }
+                } else if (elementType === "href" && info.element instanceof HTMLAnchorElement) {
+                    const hrefData = data as { href?: string; target?: string };
+                    if (hrefData.href !== undefined) {
+                        info.element.href = hrefData.href;
+                        info.element.target = hrefData.target || "";
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
                     const imageData = data as { src?: string };

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -27,8 +27,7 @@ function readTextWithBreaks(element: HTMLElement): string {
     // A <div>text</div> is a line of content.
     // Handle these before standalone <br> tags.
     clone.querySelectorAll("div").forEach((div) => {
-        const isEmptyDiv =
-            div.childNodes.length === 1 && div.firstChild instanceof HTMLBRElement;
+        const isEmptyDiv = div.childNodes.length === 1 && div.firstChild instanceof HTMLBRElement;
         // A <br> immediately before a content-bearing <div> is redundant —
         // Chrome inserts it to end the inline flow, but the block boundary
         // already creates the line break. However, before an empty

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -72,6 +72,14 @@ export class ContentManager {
      * Returns JSON string with type field for all element types.
      * Includes attributes if any have been set.
      */
+    /**
+     * Get the HTML content of an element, using Tiptap's clean output if available.
+     */
+    private getElementHTML(element: HTMLElement): string {
+        const editor = this.state.tiptapEditors.get(element);
+        return editor ? editor.getHTML() : element.innerHTML;
+    }
+
     getElementContent(key: string, info: EditableElementInfo): string {
         const elementType = this.state.editableTypes.get(key) || "html";
         const attributes = this.state.elementAttributes.get(key);
@@ -88,7 +96,7 @@ export class ContentManager {
                 type: "link",
                 href: info.element.getAttribute("href") || "",
                 target: info.element.target,
-                value: info.element.innerHTML,
+                value: this.getElementHTML(info.element),
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
@@ -103,10 +111,22 @@ export class ContentManager {
             // html (default)
             const data: HtmlContentData = {
                 type: "html",
-                value: info.element.innerHTML,
+                value: this.getElementHTML(info.element),
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
+        }
+    }
+
+    /**
+     * Set the HTML content of an element, using Tiptap's API if available.
+     */
+    private setElementHTML(element: HTMLElement, htmlContent: string): void {
+        const editor = this.state.tiptapEditors.get(element);
+        if (editor) {
+            editor.commands.setContent(htmlContent, { emitUpdate: false });
+        } else {
+            element.innerHTML = htmlContent;
         }
     }
 
@@ -131,14 +151,14 @@ export class ContentManager {
             if (data.type === "text") {
                 info.element.textContent = (data as TextContentData).value;
             } else if (data.type === "html") {
-                info.element.innerHTML = (data as HtmlContentData).value;
+                this.setElementHTML(info.element, (data as HtmlContentData).value);
             } else if (data.type === "image" && info.element instanceof HTMLImageElement) {
                 info.element.src = (data as ImageContentData).src;
             } else if (data.type === "link" && info.element instanceof HTMLAnchorElement) {
                 const linkData = data as LinkContentData;
                 info.element.href = linkData.href;
                 info.element.target = linkData.target;
-                info.element.innerHTML = linkData.value;
+                this.setElementHTML(info.element, linkData.value);
             } else if (!data.type) {
                 // No type field in JSON - use element's declared type
                 if (elementType === "link" && info.element instanceof HTMLAnchorElement) {
@@ -146,7 +166,7 @@ export class ContentManager {
                     if (linkData.href !== undefined) {
                         info.element.href = linkData.href;
                         info.element.target = linkData.target || "";
-                        info.element.innerHTML = linkData.value || "";
+                        this.setElementHTML(info.element, linkData.value || "");
                         return;
                     }
                 } else if (elementType === "image" && info.element instanceof HTMLImageElement) {
@@ -164,7 +184,7 @@ export class ContentManager {
                 } else if (elementType === "html") {
                     const htmlData = data as { value?: string };
                     if (htmlData.value !== undefined) {
-                        info.element.innerHTML = htmlData.value;
+                        this.setElementHTML(info.element, htmlData.value);
                         return;
                     }
                 }

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -57,24 +57,27 @@ function readTextWithBreaks(element: HTMLElement): string {
 
 /**
  * Whether an editable element has no visible content. Used to toggle the
- * "Click to edit" placeholder. Treats stray <br> tags (left behind by
- * contenteditable when the last character is deleted) and Tiptap's empty
- * `<p></p>` / `<p><br></p>` shells as empty.
+ * "Click to edit" placeholder so an emptied element retains a clickable area.
+ *
+ * Treats as empty:
+ * - Truly empty elements
+ * - Stray <br> from contenteditable after the last character is deleted
+ * - Tiptap's empty wrappers (<p></p>, <p><br></p>, <span><br></span>, etc.)
+ * - Whitespace-only / nbsp-only text nodes
+ *
+ * Treats as non-empty:
+ * - Any visible text (after trimming whitespace and nbsp)
+ * - Any media-like child (img, video, svg, iframe, input, button, etc.)
  */
 export function isVisuallyEmpty(element: HTMLElement): boolean {
-    for (const node of Array.from(element.childNodes)) {
-        if (node.nodeType === Node.TEXT_NODE) {
-            if ((node.textContent || "").replace(/\u00a0/g, " ").trim() !== "") {
-                return false;
-            }
-        } else if (node.nodeType === Node.ELEMENT_NODE) {
-            const el = node as HTMLElement;
-            if (el.tagName === "BR") continue;
-            if (el.tagName === "P" && isVisuallyEmpty(el)) continue;
-            return false;
-        }
+    if (
+        element.querySelector(
+            "img, video, audio, canvas, svg, iframe, input, button, picture, object, embed",
+        )
+    ) {
+        return false;
     }
-    return true;
+    return (element.textContent || "").replace(/\u00a0/g, " ").trim() === "";
 }
 
 /**

--- a/src/lazy/content-manager.ts
+++ b/src/lazy/content-manager.ts
@@ -18,6 +18,53 @@ import type {
 } from "../types.js";
 import { applyAttributesToElement } from "../types.js";
 
+function readTextWithBreaks(element: HTMLElement): string {
+    const clone = document.createElement("div");
+    clone.innerHTML = element.innerHTML;
+
+    // Chrome's contenteditable wraps each Enter in a <div>.
+    // A <div><br></div> is an empty line (the <br> is just a height placeholder).
+    // A <div>text</div> is a line of content.
+    // Handle these before standalone <br> tags.
+    clone.querySelectorAll("div").forEach((div) => {
+        const isEmptyDiv =
+            div.childNodes.length === 1 && div.firstChild instanceof HTMLBRElement;
+        // A <br> immediately before a content-bearing <div> is redundant —
+        // Chrome inserts it to end the inline flow, but the block boundary
+        // already creates the line break. However, before an empty
+        // <div><br></div> (blank line), the <br> IS a real line break.
+        const prev = div.previousSibling;
+        if (prev instanceof HTMLBRElement && !isEmptyDiv) {
+            prev.remove();
+        }
+        const newline = document.createTextNode("\n");
+        div.before(newline);
+        // Remove placeholder <br> inside otherwise-empty divs
+        if (isEmptyDiv) {
+            div.firstChild!.remove();
+        }
+        // Unwrap: move children out, remove the div shell
+        while (div.firstChild) div.before(div.firstChild);
+        div.remove();
+    });
+
+    // Handle standalone <br> tags (e.g. from our own writeTextWithBreaks or Shift+Enter)
+    clone.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
+
+    // Normalize &nbsp; (U+00A0) to regular spaces — Chrome's contenteditable
+    // inserts &nbsp; for leading/trailing spaces when splitting lines
+    return (clone.textContent || "").replace(/\u00a0/g, " ");
+}
+
+function writeTextWithBreaks(element: HTMLElement, text: string): void {
+    element.textContent = "";
+    const parts = text.split("\n");
+    for (let i = 0; i < parts.length; i++) {
+        if (i > 0) element.appendChild(document.createElement("br"));
+        if (parts[i]) element.appendChild(document.createTextNode(parts[i]));
+    }
+}
+
 export class ContentManager {
     constructor(private state: EditorState) {}
 
@@ -95,7 +142,7 @@ export class ContentManager {
         } else if (elementType === "text") {
             const data: TextContentData = {
                 type: "text",
-                value: info.element.textContent || "",
+                value: readTextWithBreaks(info.element),
                 ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
             };
             return JSON.stringify(data);
@@ -129,7 +176,7 @@ export class ContentManager {
             }
 
             if (data.type === "text") {
-                info.element.textContent = (data as TextContentData).value;
+                writeTextWithBreaks(info.element, (data as TextContentData).value);
             } else if (data.type === "html") {
                 info.element.innerHTML = (data as HtmlContentData).value;
             } else if (data.type === "image" && info.element instanceof HTMLImageElement) {
@@ -158,7 +205,7 @@ export class ContentManager {
                 } else if (elementType === "text") {
                     const textData = data as { value?: string };
                     if (textData.value !== undefined) {
-                        info.element.textContent = textData.value;
+                        writeTextWithBreaks(info.element, textData.value);
                         return;
                     }
                 } else if (elementType === "html") {

--- a/src/lazy/draft-manager.ts
+++ b/src/lazy/draft-manager.ts
@@ -9,7 +9,7 @@
 
 import type { Logger } from "loganite";
 import type { EditorState } from "./state.js";
-import { EDITABLE_SELECTOR, IMAGE_PLACEHOLDER_DATA_URI, type EditableType } from "../types.js";
+import { EDITABLE_SELECTOR, type EditableType } from "../types.js";
 
 /**
  * Storage context for an element (used for building keys)

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -242,8 +242,10 @@ export class EditingManager {
                 info.element.dataset.scmsKeydownHandler = "true";
             }
 
-            // Make text and html elements contenteditable (not images or links)
-            if (elementType === "text" || elementType === "html") {
+            // Make text elements contenteditable. For html elements, tiptap
+            // owns contenteditable — managing it here causes conflicts with
+            // tiptap's view, leading to states where the cursor disappears.
+            if (elementType === "text") {
                 info.element.setAttribute("contenteditable", "true");
             }
 
@@ -309,12 +311,16 @@ export class EditingManager {
         // Notify controller before cleanup (for formatting toolbar detach, etc.)
         this.helpers.onStopEditing(this.state.editingKey);
 
+        const elementType = this.state.editableTypes.get(this.state.editingKey) || "html";
         const infos = this.state.editableElements.get(this.state.editingKey);
         if (infos) {
             for (const info of infos) {
                 info.element.classList.remove("streamlined-editing");
                 info.element.classList.remove("streamlined-editing-sibling");
-                info.element.setAttribute("contenteditable", "false");
+                // Only manage contenteditable for text elements; tiptap owns it for html.
+                if (elementType === "text") {
+                    info.element.setAttribute("contenteditable", "false");
+                }
             }
         }
 

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -21,6 +21,8 @@ export interface EditingManagerHelpers {
     updateToolbarTemplateContext: () => void;
     getElementToKeyMap: () => WeakMap<HTMLElement, string>;
     scrollToElement: (element: HTMLElement, delay?: number) => void;
+    onStartEditing: (key: string, element: HTMLElement, elementType: string) => void;
+    onStopEditing: (key: string) => void;
 }
 
 export class EditingManager {
@@ -216,7 +218,7 @@ export class EditingManager {
                 info.element.classList.add("streamlined-editing-sibling");
             }
 
-            // Add input listener to all elements for change tracking and synchronization
+            // Add input listener for text and html elements for change tracking
             if (
                 (elementType === "text" || elementType === "html") &&
                 !info.element.dataset.scmsInputHandler
@@ -241,7 +243,6 @@ export class EditingManager {
             }
 
             // Make text and html elements contenteditable (not images or links)
-            // Only the primary element is focused, but all are editable for consistency
             if (elementType === "text" || elementType === "html") {
                 info.element.setAttribute("contenteditable", "true");
             }
@@ -254,6 +255,9 @@ export class EditingManager {
 
         // Focus the primary element (all types need focus for keyboard navigation)
         primaryInfo.element.focus();
+
+        // Notify controller that editing started (for formatting toolbar, etc.)
+        this.helpers.onStartEditing(key, primaryInfo.element, elementType);
 
         // On mobile, scroll the element into view after keyboard opens
         if (window.innerWidth < 640) {
@@ -301,6 +305,9 @@ export class EditingManager {
         }
 
         this.log.trace("Stopping edit");
+
+        // Notify controller before cleanup (for formatting toolbar detach, etc.)
+        this.helpers.onStopEditing(this.state.editingKey);
 
         const infos = this.state.editableElements.get(this.state.editingKey);
         if (infos) {

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -21,7 +21,12 @@ export interface EditingManagerHelpers {
     updateToolbarTemplateContext: () => void;
     getElementToKeyMap: () => WeakMap<HTMLElement, string>;
     scrollToElement: (element: HTMLElement, delay?: number) => void;
-    onStartEditing: (key: string, element: HTMLElement, elementType: string) => void;
+    onStartEditing: (
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+        coords?: { x: number; y: number },
+    ) => void;
     onStopEditing: (key: string) => void;
 }
 
@@ -205,7 +210,11 @@ export class EditingManager {
     /**
      * Start editing an element (makes it contenteditable and focuses it).
      */
-    startEditing(key: string, clickedElement?: HTMLElement): void {
+    startEditing(
+        key: string,
+        clickedElement?: HTMLElement,
+        coords?: { x: number; y: number },
+    ): void {
         const infos = this.state.editableElements.get(key);
         if (!infos || infos.length === 0) {
             this.log.warn("Element not found", { key });
@@ -296,7 +305,7 @@ export class EditingManager {
         primaryInfo.element.focus();
 
         // Notify controller that editing started (for formatting toolbar, etc.)
-        this.helpers.onStartEditing(key, primaryInfo.element, elementType);
+        this.helpers.onStartEditing(key, primaryInfo.element, elementType, coords);
 
         // On mobile, scroll the element into view after keyboard opens
         if (window.innerWidth < 640) {

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -93,10 +93,46 @@ export class EditingManager {
         if (this.state.toolbar) {
             this.state.toolbar.activeElement = key;
             this.state.toolbar.activeElementType = elementType;
+            this.state.toolbar.hasOuterEditable = this.findOuterEditableKey() !== null;
         }
 
         // Update template context on toolbar
         this.helpers.updateToolbarTemplateContext();
+    }
+
+    /**
+     * Find the nearest editable ancestor of the currently-selected element.
+     * Returns its storage key, or null if there's no editable ancestor or
+     * nothing is currently selected.
+     */
+    findOuterEditableKey(): string | null {
+        if (!this.state.selectedKey) return null;
+        const infos = this.state.editableElements.get(this.state.selectedKey);
+        const primary = infos?.[0];
+        if (!primary) return null;
+        const elementToKey = this.helpers.getElementToKeyMap();
+        let current = primary.element.parentElement;
+        while (current) {
+            const key = elementToKey.get(current);
+            if (key && key !== this.state.selectedKey) return key;
+            current = current.parentElement;
+        }
+        return null;
+    }
+
+    /**
+     * Select the nearest editable ancestor of the currently-selected element.
+     * Used when a nested editable fills its parent's interior and the outer
+     * element can't be clicked directly.
+     */
+    selectOuterEditable(): void {
+        const outerKey = this.findOuterEditableKey();
+        if (!outerKey) return;
+        const infos = this.state.editableElements.get(outerKey);
+        const outerElement = infos?.[0]?.element;
+        if (!outerElement) return;
+        // Use startEditing to match the normal click behavior (desktop).
+        this.startEditing(outerKey, outerElement);
     }
 
     /**
@@ -119,6 +155,7 @@ export class EditingManager {
         if (!this.state.editingKey && this.state.toolbar) {
             this.state.toolbar.activeElement = null;
             this.state.toolbar.activeElementType = null;
+            this.state.toolbar.hasOuterEditable = false;
         }
     }
 

--- a/src/lazy/editing-manager.ts
+++ b/src/lazy/editing-manager.ts
@@ -250,7 +250,7 @@ export class EditingManager {
             }
 
             // Make images and links focusable for keyboard navigation
-            if (elementType === "image" || elementType === "link") {
+            if (elementType === "image" || elementType === "link" || elementType === "href") {
                 info.element.setAttribute("tabindex", "-1");
             }
         }

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1016,6 +1016,10 @@ class EditorController {
             this.contentViewerManager.toggle();
         });
 
+        toolbar.addEventListener("select-outer", () => {
+            this.editingManager.selectOuterEditable();
+        });
+
         toolbar.addEventListener("show-hidden-elements", () => {
             this.contentViewerManager.showHiddenPanel();
         });

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -79,7 +79,7 @@ import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HelpPanel } from "../components/help-panel.js";
 import { createEditorState, type EditorState, type EditableElementInfo } from "./state.js";
 import { DraftManager } from "./draft-manager.js";
-import { ContentManager } from "./content-manager.js";
+import { ContentManager, updateEmptyState } from "./content-manager.js";
 import { TemplateManager } from "./template-manager.js";
 import { EditingManager } from "./editing-manager.js";
 import { ModalManager } from "./modal-manager.js";
@@ -856,6 +856,7 @@ class EditorController {
         this.state.editableElements.forEach((infos, key) => {
             for (const info of infos) {
                 info.element.classList.add("streamlined-editable");
+                updateEmptyState(info.element);
                 this.setupElementClickHandler(info.element, key);
             }
         });
@@ -877,6 +878,7 @@ class EditorController {
             for (const info of infos) {
                 info.element.classList.remove(
                     "streamlined-editable",
+                    "streamlined-empty",
                     "streamlined-selected",
                     "streamlined-selected-sibling",
                     "streamlined-editing",

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -797,12 +797,10 @@ class EditorController {
                         now - this.state.lastTapTime < this.doubleTapDelay;
 
                     if (isDoubleTap && isMobile) {
-                        // Mobile double-tap: open media manager for images, navigate for links
-                        // (Desktop uses native dblclick event instead)
+                        // Mobile double-tap: open media manager for images
+                        // (Link "go to" is handled by the formatting toolbar)
                         if (elementType === "image") {
                             this.modalManager.handleChangeImage();
-                        } else if (elementType === "link") {
-                            this.modalManager.handleGoToLink();
                         }
                         this.state.lastTapKey = null;
                         this.state.lastTapTime = 0;
@@ -845,17 +843,7 @@ class EditorController {
             element.dataset.scmsDblClickHandler = "true";
         }
 
-        // Double-click handler for links to navigate (desktop)
-        if (elementType === "link" && !element.dataset.scmsDblClickHandler) {
-            element.addEventListener("dblclick", (e) => {
-                if (this.state.editingEnabled) {
-                    e.preventDefault();
-                    e.stopImmediatePropagation();
-                    this.modalManager.handleGoToLink();
-                }
-            });
-            element.dataset.scmsDblClickHandler = "true";
-        }
+        // Link "go to" is handled by the formatting toolbar's Go to Link button
     }
 
     /**
@@ -1094,7 +1082,7 @@ class EditorController {
     ): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
-            const compact = elementType === "link";
+            const linkMode = elementType === "link";
 
             // Wire up content sync for this element
             toolbar.onContentUpdate = () => {
@@ -1106,7 +1094,7 @@ class EditorController {
             };
 
             // Attach (reuses existing editor if available, creates new otherwise)
-            toolbar.attach(element, compact);
+            toolbar.attach(element, linkMode);
 
             // Register editor in state so content manager can use Tiptap's API.
             if (toolbar.editor) {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -645,12 +645,30 @@ class EditorController {
      * Get editable info from element by checking data-scms-{type} attributes
      */
     private getEditableInfo(element: HTMLElement): { id: string; type: EditableType } | null {
-        const types: EditableType[] = ["text", "html", "image", "link"];
+        const types: EditableType[] = ["text", "html", "image", "link", "href"];
+        const matches: { id: string; type: EditableType }[] = [];
         for (const type of types) {
             const id = element.getAttribute(`data-scms-${type}`);
-            if (id) return { id, type };
+            if (id) matches.push({ id, type });
         }
-        return null;
+        if (matches.length === 0) return null;
+        if (matches.length > 1) {
+            this.log.warn(
+                `Element has multiple data-scms-* attributes (${matches
+                    .map((m) => `data-scms-${m.type}`)
+                    .join(", ")}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
+                { element },
+            );
+        }
+        const first = matches[0];
+        if (first.type === "href" && !(element instanceof HTMLAnchorElement)) {
+            this.log.warn(
+                `data-scms-href can only be used on <a> elements. Element will be skipped.`,
+                { element },
+            );
+            return null;
+        }
+        return first;
     }
 
     /**
@@ -663,7 +681,8 @@ class EditorController {
             instanceElement.hasAttribute("data-scms-text") ||
             instanceElement.hasAttribute("data-scms-html") ||
             instanceElement.hasAttribute("data-scms-image") ||
-            instanceElement.hasAttribute("data-scms-link")
+            instanceElement.hasAttribute("data-scms-link") ||
+            instanceElement.hasAttribute("data-scms-href")
         );
     }
 
@@ -806,7 +825,11 @@ class EditorController {
                         this.state.lastTapTime = 0;
                     } else if (isMobile) {
                         // Mobile: images and links go straight to editing, others use two-step
-                        if (elementType === "image" || elementType === "link") {
+                        if (
+                            elementType === "image" ||
+                            elementType === "link" ||
+                            elementType === "href"
+                        ) {
                             this.editingManager.startEditing(key, element);
                         } else if (
                             this.state.selectedKey === key &&

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -63,6 +63,7 @@ function getConfigFromScriptTag(): ViewerConfig | null {
 // Import Lit components to register them
 import "../components/toolbar.js";
 import "../components/sign-in-link.js";
+import "../components/rich-text-editor.js";
 import "../components/html-editor-modal.js";
 import "../components/link-editor-modal.js";
 import "../components/seo-modal.js";

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -228,8 +228,8 @@ class EditorController {
             updateToolbarTemplateContext: () => this.templateManager.updateToolbarTemplateContext(),
             getElementToKeyMap: () => this.elementToKey,
             scrollToElement: this.scrollToElement.bind(this),
-            onStartEditing: (key, element, elementType) =>
-                this.handleEditingStarted(key, element, elementType),
+            onStartEditing: (key, element, elementType, coords) =>
+                this.handleEditingStarted(key, element, elementType, coords),
             onStopEditing: (key) => this.handleEditingStopped(key),
         });
 
@@ -826,19 +826,20 @@ class EditorController {
                         this.state.lastTapKey = null;
                         this.state.lastTapTime = 0;
                     } else if (isMobile) {
+                        const coords = { x: e.clientX, y: e.clientY };
                         // Mobile: images and links go straight to editing, others use two-step
                         if (
                             elementType === "image" ||
                             elementType === "link" ||
                             elementType === "href"
                         ) {
-                            this.editingManager.startEditing(key, element);
+                            this.editingManager.startEditing(key, element, coords);
                         } else if (
                             this.state.selectedKey === key &&
                             this.state.editingKey !== key
                         ) {
                             // Two-step: second tap edits
-                            this.editingManager.startEditing(key, element);
+                            this.editingManager.startEditing(key, element, coords);
                         } else {
                             // Two-step: first tap selects
                             this.editingManager.selectElement(key, element);
@@ -847,7 +848,10 @@ class EditorController {
                         this.state.lastTapTime = now;
                     } else {
                         // Desktop: edit immediately
-                        this.editingManager.startEditing(key, element);
+                        this.editingManager.startEditing(key, element, {
+                            x: e.clientX,
+                            y: e.clientY,
+                        });
                         this.state.lastTapKey = key;
                         this.state.lastTapTime = now;
                     }
@@ -1104,7 +1108,12 @@ class EditorController {
      * Attaches or reuses a Tiptap editor for html/link element types.
      * Editors are preserved across blur/focus to maintain undo history.
      */
-    private handleEditingStarted(key: string, element: HTMLElement, elementType: string): void {
+    private handleEditingStarted(
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+        coords?: { x: number; y: number },
+    ): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
             const linkMode = elementType === "link";
@@ -1119,7 +1128,7 @@ class EditorController {
             };
 
             // Attach (reuses existing editor if available, creates new otherwise)
-            toolbar.attach(element, linkMode);
+            toolbar.attach(element, linkMode, coords);
 
             // Register editor in state so content manager can use Tiptap's API.
             if (toolbar.editor) {

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1124,9 +1124,7 @@ class EditorController {
         if (type === "text") {
             // Check for HTML elements other than <br> (which we allow for line breaks)
             const hasNonBrElements = Array.from(element.childNodes).some(
-                (node) =>
-                    node.nodeType === Node.ELEMENT_NODE &&
-                    (node as Element).tagName !== "BR",
+                (node) => node.nodeType === Node.ELEMENT_NODE && (node as Element).tagName !== "BR",
             );
             if (hasNonBrElements) {
                 const id = element.getAttribute("data-scms-text");

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1060,9 +1060,7 @@ class EditorController {
      */
     private ensureFormattingToolbar(): FormattingToolbar {
         if (!this.state.formattingToolbar) {
-            const toolbar = document.createElement(
-                "scms-formatting-toolbar",
-            ) as FormattingToolbar;
+            const toolbar = document.createElement("scms-formatting-toolbar") as FormattingToolbar;
             toolbar.style.display = "none";
             document.body.appendChild(toolbar);
             this.state.formattingToolbar = toolbar;
@@ -1075,11 +1073,7 @@ class EditorController {
      * Attaches or reuses a Tiptap editor for html/link element types.
      * Editors are preserved across blur/focus to maintain undo history.
      */
-    private handleEditingStarted(
-        key: string,
-        element: HTMLElement,
-        elementType: string,
-    ): void {
+    private handleEditingStarted(key: string, element: HTMLElement, elementType: string): void {
         if (elementType === "html" || elementType === "link") {
             const toolbar = this.ensureFormattingToolbar();
             const linkMode = elementType === "link";

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -656,7 +656,9 @@ class EditorController {
             this.log.warn(
                 `Element has multiple data-scms-* attributes (${matches
                     .map((m) => `data-scms-${m.type}`)
-                    .join(", ")}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
+                    .join(
+                        ", ",
+                    )}). Only the first ("data-scms-${matches[0].type}") will be used; nest editables to combine behaviors.`,
                 { element },
             );
         }

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -9,6 +9,7 @@
  * - Editing functionality
  */
 
+import { markRaw } from "@vue/reactivity";
 import { Logger } from "loganite";
 import { KeyStorage, type EditorMode } from "../key-storage.js";
 import { PopupManager, type MediaFile } from "../popup-manager.js";
@@ -74,6 +75,7 @@ import "../components/help-panel.js";
 import "../components/content-viewer-badge.js";
 import "../components/content-viewer-panel.js";
 import type { Toolbar } from "../components/toolbar.js";
+import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HelpPanel } from "../components/help-panel.js";
 import { createEditorState, type EditorState, type EditableElementInfo } from "./state.js";
 import { DraftManager } from "./draft-manager.js";
@@ -226,6 +228,9 @@ class EditorController {
             updateToolbarTemplateContext: () => this.templateManager.updateToolbarTemplateContext(),
             getElementToKeyMap: () => this.elementToKey,
             scrollToElement: this.scrollToElement.bind(this),
+            onStartEditing: (key, element, elementType) =>
+                this.handleEditingStarted(key, element, elementType),
+            onStopEditing: (key) => this.handleEditingStopped(key),
         });
 
         // Initialize modal manager
@@ -1053,6 +1058,101 @@ class EditorController {
             this.spacerElement.remove();
             this.spacerElement = null;
         }
+        // Also remove formatting toolbar
+        this.detachFormattingToolbar();
+        if (this.state.formattingToolbar) {
+            this.state.formattingToolbar.remove();
+            this.state.formattingToolbar = null;
+        }
+    }
+
+    /**
+     * Ensure the formatting toolbar component exists in the DOM.
+     * Created once and reused across editing sessions.
+     */
+    private ensureFormattingToolbar(): FormattingToolbar {
+        if (!this.state.formattingToolbar) {
+            const toolbar = document.createElement(
+                "scms-formatting-toolbar",
+            ) as FormattingToolbar;
+            toolbar.style.display = "none";
+            document.body.appendChild(toolbar);
+            this.state.formattingToolbar = toolbar;
+        }
+        return this.state.formattingToolbar;
+    }
+
+    /**
+     * Called when editing starts on an element.
+     * Attaches or reuses a Tiptap editor for html/link element types.
+     * Editors are preserved across blur/focus to maintain undo history.
+     */
+    private handleEditingStarted(
+        key: string,
+        element: HTMLElement,
+        elementType: string,
+    ): void {
+        if (elementType === "html" || elementType === "link") {
+            const toolbar = this.ensureFormattingToolbar();
+            const compact = elementType === "link";
+
+            // Wire up content sync for this element
+            toolbar.onContentUpdate = () => {
+                const infos = this.state.editableElements.get(key);
+                if (!infos || infos.length === 0) return;
+                const sourceInfo = infos.find((i) => i.element === element) || infos[0];
+                this.contentManager.updateContentFromElement(key, sourceInfo.element);
+                this.saveManager.updateToolbarHasChanges();
+            };
+
+            // Attach (reuses existing editor if available, creates new otherwise)
+            toolbar.attach(element, compact);
+
+            // Register editor in state so content manager can use Tiptap's API.
+            if (toolbar.editor) {
+                this.state.tiptapEditors.set(element, markRaw(toolbar.editor));
+            }
+        }
+    }
+
+    /**
+     * Called when editing stops on an element.
+     * Hides the formatting toolbar but keeps the editor alive for undo history.
+     */
+    private handleEditingStopped(_key: string): void {
+        if (!this.state.formattingToolbar) return;
+        this.state.formattingToolbar.style.display = "none";
+    }
+
+    /**
+     * Destroy all formatting toolbar editors, sync changed content, and clean up.
+     * Called when editing is disabled (sign out, mode change).
+     */
+    private detachFormattingToolbar(): void {
+        if (!this.state.formattingToolbar) return;
+
+        const toolbar = this.state.formattingToolbar;
+
+        // Sync and unregister each editor that has changes
+        for (const [element] of toolbar.editors) {
+            this.state.tiptapEditors.delete(element);
+
+            // Find the key for this element
+            if (toolbar.hasChangesFor(element)) {
+                for (const [k, infos] of this.state.editableElements) {
+                    if (infos.some((i) => i.element === element)) {
+                        toolbar.detachElement(element);
+                        this.contentManager.updateContentFromElement(k, infos[0].element);
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Destroy any remaining editors
+        toolbar.detach();
+        toolbar.onContentUpdate = null;
+        this.saveManager.updateToolbarHasChanges();
     }
 
     /**

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1122,18 +1122,30 @@ class EditorController {
      */
     private normalizeDomWhitespace(element: HTMLElement, type: EditableType): void {
         if (type === "text") {
-            // Check for actual HTML elements (not just entity-encoded text like &amp;)
-            const hasHtmlElements = Array.from(element.childNodes).some(
-                (node) => node.nodeType === Node.ELEMENT_NODE,
+            // Check for HTML elements other than <br> (which we allow for line breaks)
+            const hasNonBrElements = Array.from(element.childNodes).some(
+                (node) =>
+                    node.nodeType === Node.ELEMENT_NODE &&
+                    (node as Element).tagName !== "BR",
             );
-            if (hasHtmlElements) {
+            if (hasNonBrElements) {
                 const id = element.getAttribute("data-scms-text");
                 this.log.warn(
                     `Element "${id}" has data-scms-text but contains HTML. Use data-scms-html to preserve formatting.`,
                     { innerHTML: element.innerHTML },
                 );
             }
-            element.textContent = normalizeWhitespace(element.textContent || "");
+            // Normalize each text node's whitespace while preserving <br> line breaks
+            const hasBr = element.querySelector("br") !== null;
+            if (hasBr) {
+                for (const node of Array.from(element.childNodes)) {
+                    if (node.nodeType === Node.TEXT_NODE) {
+                        node.textContent = normalizeWhitespace(node.textContent || "");
+                    }
+                }
+            } else {
+                element.textContent = normalizeWhitespace(element.textContent || "");
+            }
         } else if (type === "html") {
             element.innerHTML = normalizeHtmlWhitespace(element.innerHTML);
         } else if (type === "link" && element instanceof HTMLAnchorElement) {

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -197,7 +197,10 @@ export class ModalManager {
         if (storedContent) {
             try {
                 const data = JSON.parse(storedContent) as { type?: string; value?: string };
-                if ((data.type === "html" || data.type === "text" || data.type === "link") && data.value !== undefined) {
+                if (
+                    (data.type === "html" || data.type === "text" || data.type === "link") &&
+                    data.value !== undefined
+                ) {
                     htmlValue = data.value;
                 }
             } catch {

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -197,7 +197,7 @@ export class ModalManager {
         if (storedContent) {
             try {
                 const data = JSON.parse(storedContent) as { type?: string; value?: string };
-                if ((data.type === "html" || data.type === "text") && data.value !== undefined) {
+                if ((data.type === "html" || data.type === "text" || data.type === "link") && data.value !== undefined) {
                     htmlValue = data.value;
                 }
             } catch {
@@ -216,14 +216,30 @@ export class ModalManager {
         });
 
         modal.addEventListener("apply", ((e: CustomEvent<{ content: string }>) => {
-            // Build content and update via setContent
+            const elementType = this.state.editableTypes?.get(key) || "html";
             const attributes = this.state.elementAttributes.get(key);
-            const data: HtmlContentData = {
-                type: "html",
-                value: e.detail.content,
-                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
-            };
-            this.contentManager.setContent(key, JSON.stringify(data));
+
+            let content: string;
+            if (elementType === "link" && primaryInfo.element instanceof HTMLAnchorElement) {
+                // For links, update the value (innerHTML) while preserving href/target
+                const data: LinkContentData = {
+                    type: "link",
+                    href: primaryInfo.element.getAttribute("href") || "",
+                    target: primaryInfo.element.target,
+                    value: e.detail.content,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            } else {
+                const data: HtmlContentData = {
+                    type: "html",
+                    value: e.detail.content,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            }
+
+            this.contentManager.setContent(key, content);
             this.closeModal("htmlEditorModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("HTML applied", {
@@ -270,10 +286,25 @@ export class ModalManager {
         // Create and show modal
         const modal = document.createElement("scms-link-editor-modal") as LinkEditorModal;
         modal.elementId = key;
+        // Read link value from stored content if available (avoids Tiptap normalization),
+        // fall back to DOM innerHTML
+        let linkValue = primaryAnchor.innerHTML;
+        const storedContent = this.state.currentContent.get(key);
+        if (storedContent) {
+            try {
+                const data = JSON.parse(storedContent) as { type?: string; value?: string };
+                if (data.type === "link" && data.value !== undefined) {
+                    linkValue = data.value;
+                }
+            } catch {
+                // Use DOM fallback
+            }
+        }
+
         modal.linkData = {
             href: primaryAnchor.getAttribute("href") || "",
             target: primaryAnchor.target,
-            value: primaryAnchor.innerHTML,
+            value: linkValue,
         };
 
         // Prevent clicks inside modal from deselecting the element

--- a/src/lazy/modal-manager.ts
+++ b/src/lazy/modal-manager.ts
@@ -19,6 +19,7 @@ import type {
     HtmlContentData,
     ImageContentData,
     LinkContentData,
+    HrefContentData,
 } from "../types.js";
 import {
     ELEMENT_ATTRIBUTES,
@@ -282,6 +283,7 @@ export class ModalManager {
             return;
         }
 
+        const elementType = this.state.editableTypes.get(key) || "html";
         const primaryInfo = infos[0];
         const primaryAnchor = primaryInfo.element as HTMLAnchorElement;
         this.log.debug("Opening link editor", { key, elementId: primaryInfo.elementId });
@@ -290,7 +292,7 @@ export class ModalManager {
         const modal = document.createElement("scms-link-editor-modal") as LinkEditorModal;
         modal.elementId = key;
         // Read link value from stored content if available (avoids Tiptap normalization),
-        // fall back to DOM innerHTML
+        // fall back to DOM innerHTML. href type has no value to edit.
         let linkValue = primaryAnchor.innerHTML;
         const storedContent = this.state.currentContent.get(key);
         if (storedContent) {
@@ -318,14 +320,26 @@ export class ModalManager {
         modal.addEventListener("apply", ((e: CustomEvent<{ linkData: LinkData }>) => {
             // Build content and update via setContent
             const attributes = this.state.elementAttributes.get(key);
-            const data: LinkContentData = {
-                type: "link",
-                href: e.detail.linkData.href,
-                target: e.detail.linkData.target,
-                value: e.detail.linkData.value,
-                ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
-            };
-            this.contentManager.setContent(key, JSON.stringify(data));
+            let content: string;
+            if (elementType === "href") {
+                const data: HrefContentData = {
+                    type: "href",
+                    href: e.detail.linkData.href,
+                    target: e.detail.linkData.target,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            } else {
+                const data: LinkContentData = {
+                    type: "link",
+                    href: e.detail.linkData.href,
+                    target: e.detail.linkData.target,
+                    value: e.detail.linkData.value,
+                    ...(attributes && Object.keys(attributes).length > 0 ? { attributes } : {}),
+                };
+                content = JSON.stringify(data);
+            }
+            this.contentManager.setContent(key, content);
             this.closeModal("linkEditorModal");
             this.helpers.updateToolbarHasChanges();
             this.log.debug("Link updated", {

--- a/src/lazy/state.ts
+++ b/src/lazy/state.ts
@@ -11,7 +11,9 @@ import type Sortable from "sortablejs";
 import type { EditorMode } from "../key-storage.js";
 import type { AppPermissions, EditableType, ElementAttributes } from "../types.js";
 import type { Toolbar } from "../components/toolbar.js";
+import type { FormattingToolbar } from "../components/rich-text-editor.js";
 import type { HtmlEditorModal } from "../components/html-editor-modal.js";
+
 import type { LinkEditorModal } from "../components/link-editor-modal.js";
 import type { SeoModal } from "../components/seo-modal.js";
 import type { AccessibilityModal } from "../components/accessibility-modal.js";
@@ -43,6 +45,18 @@ export interface TemplateInfo {
 }
 
 /**
+ * Minimal interface for a rich text editor attached to an element.
+ * Used by the content manager to read/write content via Tiptap
+ * without importing the full Tiptap dependency.
+ */
+export interface RichTextEditorHandle {
+    getHTML(): string;
+    commands: {
+        setContent(content: string, options?: { emitUpdate?: boolean }): boolean;
+    };
+}
+
+/**
  * The reactive state shared across all managers
  */
 export interface EditorState {
@@ -70,6 +84,9 @@ export interface EditorState {
     editingKey: string | null;
     selectedInstance: HTMLElement | null;
 
+    // Rich text editors attached to elements (Tiptap)
+    tiptapEditors: Map<HTMLElement, RichTextEditorHandle>;
+
     // Templates
     templates: Map<string, TemplateInfo>;
     templateAddButtons: Map<string, HTMLButtonElement>;
@@ -77,6 +94,7 @@ export interface EditorState {
 
     // UI components
     toolbar: Toolbar | null;
+    formattingToolbar: FormattingToolbar | null;
     htmlEditorModal: HtmlEditorModal | null;
     linkEditorModal: LinkEditorModal | null;
     seoModal: SeoModal | null;
@@ -121,6 +139,9 @@ export function createEditorState(): EditorState {
         editingKey: null,
         selectedInstance: null,
 
+        // Rich text editors
+        tiptapEditors: new Map(),
+
         // Templates
         templates: new Map(),
         templateAddButtons: new Map(),
@@ -128,6 +149,7 @@ export function createEditorState(): EditorState {
 
         // UI components
         toolbar: null,
+        formattingToolbar: null,
         htmlEditorModal: null,
         linkEditorModal: null,
         seoModal: null,

--- a/src/lazy/styles.ts
+++ b/src/lazy/styles.ts
@@ -61,6 +61,14 @@ export function injectEditStyles(): void {
             outline-offset: -2px;
         }
 
+        /* Non-image editables: semi-transparent solid outline for selected/editing so the caret stays visible */
+        .streamlined-editable.streamlined-selected:not([data-scms-image]),
+        .streamlined-editable.streamlined-editing:not([data-scms-image]),
+        .streamlined-editable.streamlined-editing-sibling:not([data-scms-image]) {
+            outline: 2px solid rgb(255 0 0 / 30%);
+            outline-offset: -2px;
+        }
+
         /* Template instance controls */
         .scms-instance-delete {
             position: absolute;

--- a/src/lazy/styles.ts
+++ b/src/lazy/styles.ts
@@ -35,7 +35,7 @@ export function injectEditStyles(): void {
             outline-color: #ef4444;
         }
 
-        .streamlined-editable:empty::before {
+        .streamlined-editable.streamlined-empty::before {
             content: "Click to edit";
             color: #9ca3af;
             font-style: italic;

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -98,14 +98,25 @@ export class TemplateManager {
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
-            el.innerHTML = "";
+            // href elements don't own their inner content — the developer-authored
+            // markup (icons, spans, nested editables) must survive into clones.
+            if (!el.hasAttribute("data-scms-href")) {
+                el.innerHTML = "";
+            }
         });
 
-        // Replace all text nodes with empty strings
+        // Replace all text nodes with empty strings, except those inside
+        // data-scms-href elements — their descendant text is developer-authored
+        // layout that must survive into instance clones. Text inside a nested
+        // editable of another type (e.g. data-scms-text inside data-scms-href)
+        // is still blanked because the nearest editable ancestor owns it.
         const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT);
         const textNodes: Text[] = [];
         while (walker.nextNode()) {
-            textNodes.push(walker.currentNode as Text);
+            const node = walker.currentNode as Text;
+            const nearestEditable = node.parentElement?.closest(EDITABLE_SELECTOR);
+            if (nearestEditable?.hasAttribute("data-scms-href")) continue;
+            textNodes.push(node);
         }
         textNodes.forEach((node) => (node.textContent = ""));
 

--- a/src/lazy/template-manager.ts
+++ b/src/lazy/template-manager.ts
@@ -12,6 +12,7 @@ import type { Logger } from "loganite";
 import Sortable from "sortablejs";
 import type { EditorState, TemplateInfo, EditableElementInfo } from "./state.js";
 import type { ContentManager } from "./content-manager.js";
+import { updateEmptyState } from "./content-manager.js";
 import type { UndoManager } from "./undo-manager.js";
 import { EDITABLE_SELECTOR, IMAGE_PLACEHOLDER_DATA_URI, type EditableType } from "../types.js";
 
@@ -1043,6 +1044,7 @@ export class TemplateManager {
             if (!key) return;
 
             element.classList.add("streamlined-editable");
+            updateEmptyState(element);
             this.helpers.setupElementClickHandler(element, key);
         });
 

--- a/src/lazy/tours/link-editing/desktop.ts
+++ b/src/lazy/tours/link-editing/desktop.ts
@@ -101,7 +101,6 @@ export function linkEditorStepDesktop(ctx: TourContext): TourStep {
     };
 }
 
-
 /**
  * Step pointing to Save button
  */

--- a/src/lazy/tours/link-editing/desktop.ts
+++ b/src/lazy/tours/link-editing/desktop.ts
@@ -101,21 +101,6 @@ export function linkEditorStepDesktop(ctx: TourContext): TourStep {
     };
 }
 
-/**
- * Step mentioning double-click behavior
- */
-export function goToLinkTipDesktop(ctx: TourContext): TourStep {
-    return {
-        element: () => ctx.findVisibleElement(".streamlined-editing[data-scms-link]"),
-        popover: {
-            title: "Quick Tip",
-            description: "You can double-click any link to go to its destination.",
-            side: "bottom",
-            align: "center",
-            showButtons: ["next", "close"],
-        },
-    };
-}
 
 /**
  * Step pointing to Save button

--- a/src/lazy/tours/link-editing/index.ts
+++ b/src/lazy/tours/link-editing/index.ts
@@ -7,7 +7,6 @@ import {
     selectLinkStepDesktop,
     editLinkStepDesktop,
     linkEditorStepDesktop,
-    goToLinkTipDesktop,
     saveStepDesktop,
 } from "./desktop";
 import {
@@ -16,7 +15,6 @@ import {
     openElementSectionStepMobile,
     editLinkStepMobile,
     linkEditorStepMobile,
-    goToLinkTipMobile,
     saveStepMobile,
 } from "./mobile";
 
@@ -54,7 +52,6 @@ export const linkEditingTour: TourDefinition = {
                 openElementSectionStepMobile(ctx),
                 editLinkStepMobile(ctx),
                 linkEditorStepMobile(ctx),
-                goToLinkTipMobile(ctx),
                 saveStepMobile(),
             ];
         }
@@ -63,7 +60,6 @@ export const linkEditingTour: TourDefinition = {
             selectLinkStepDesktop(ctx),
             editLinkStepDesktop(ctx),
             linkEditorStepDesktop(ctx),
-            goToLinkTipDesktop(ctx),
             saveStepDesktop(),
         ];
     },

--- a/src/lazy/tours/link-editing/mobile.ts
+++ b/src/lazy/tours/link-editing/mobile.ts
@@ -171,21 +171,6 @@ export function linkEditorStepMobile(ctx: TourContext): TourStep {
     };
 }
 
-/**
- * Step mentioning double-tap behavior
- */
-export function goToLinkTipMobile(ctx: TourContext): TourStep {
-    return {
-        element: () => ctx.findVisibleElement(".streamlined-editing[data-scms-link]"),
-        popover: {
-            title: "Quick Tip",
-            description: "You can double-tap any link to go to its destination.",
-            side: "bottom",
-            align: "center",
-            showButtons: ["next", "close"],
-        },
-    };
-}
 
 /**
  * Step pointing to Save button

--- a/src/lazy/tours/link-editing/mobile.ts
+++ b/src/lazy/tours/link-editing/mobile.ts
@@ -171,7 +171,6 @@ export function linkEditorStepMobile(ctx: TourContext): TourStep {
     };
 }
 
-
 /**
  * Step pointing to Save button
  */

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -75,7 +75,7 @@
     /**
      * Editable element types
      */
-    type EditableType = "text" | "html" | "image" | "link";
+    type EditableType = "text" | "html" | "image" | "link" | "href";
 
     /**
      * Element info including optional group, template context, and type
@@ -166,7 +166,7 @@
         // For editable elements, strip all attributes except reserved ones
         // This handles src, href, alt, title, and any custom attributes set via modals
         const editableSelector =
-            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         div.querySelectorAll(editableSelector).forEach((el) => {
             const attributesToRemove: string[] = [];
             for (let i = 0; i < el.attributes.length; i++) {
@@ -182,14 +182,21 @@
                 attributesToRemove.push(attr.name);
             }
             attributesToRemove.forEach((name) => el.removeAttribute(name));
-            el.innerHTML = "";
+            // href elements don't own inner content — preserve developer markup.
+            if (!el.hasAttribute("data-scms-href")) {
+                el.innerHTML = "";
+            }
         });
 
-        // Replace all text nodes with empty strings
+        // Replace all text nodes with empty strings, except those inside
+        // data-scms-href elements (where developer layout lives).
         const walker = document.createTreeWalker(div, NodeFilter.SHOW_TEXT);
         const textNodes: Text[] = [];
         while (walker.nextNode()) {
-            textNodes.push(walker.currentNode as Text);
+            const node = walker.currentNode as Text;
+            const nearestEditable = node.parentElement?.closest(editableSelector);
+            if (nearestEditable?.hasAttribute("data-scms-href")) continue;
+            textNodes.push(node);
         }
         textNodes.forEach((node) => (node.textContent = ""));
 
@@ -379,10 +386,15 @@
      * Get editable info from element by checking data-scms-{type} attributes
      */
     function getEditableInfo(element: HTMLElement): { id: string; type: EditableType } | null {
-        const types: EditableType[] = ["text", "html", "image", "link"];
+        const types: EditableType[] = ["text", "html", "image", "link", "href"];
         for (const type of types) {
             const id = element.getAttribute(`data-scms-${type}`);
-            if (id) return { id, type };
+            if (id) {
+                if (type === "href" && !(element instanceof HTMLAnchorElement)) {
+                    return null;
+                }
+                return { id, type };
+            }
         }
         return null;
     }
@@ -422,7 +434,7 @@
      */
     function scanEditableElements(): Map<string, EditableElementInfo[]> {
         const elements = new Map<string, EditableElementInfo[]>();
-        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
             const info = getEditableInfo(element);
             if (info) {
@@ -596,6 +608,11 @@
                 element.target = linkData.target;
                 element.innerHTML = linkData.value;
                 return element;
+            } else if (data.type === "href" && element instanceof HTMLAnchorElement) {
+                const hrefData = data as { type: "href"; href: string; target: string };
+                element.href = hrefData.href;
+                element.target = hrefData.target;
+                return element;
             } else if (data.type) {
                 // Unknown type with type field - don't process
                 return element;
@@ -608,6 +625,12 @@
                     element.href = linkData.href;
                     element.target = linkData.target || "";
                     element.innerHTML = linkData.value || "";
+                }
+            } else if (type === "href" && element instanceof HTMLAnchorElement) {
+                const hrefData = data as { href?: string; target?: string };
+                if (hrefData.href !== undefined) {
+                    element.href = hrefData.href;
+                    element.target = hrefData.target || "";
                 }
             } else if (type === "image" && element instanceof HTMLImageElement) {
                 const imageData = data as { src?: string };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -136,6 +136,19 @@
     }
 
     /**
+     * Set text content with \n converted to <br> elements.
+     * Uses DOM APIs (createTextNode + createElement) to avoid XSS from innerHTML.
+     */
+    function setTextWithBreaks(element: HTMLElement, text: string): void {
+        element.textContent = "";
+        const parts = text.split("\n");
+        for (let i = 0; i < parts.length; i++) {
+            if (i > 0) element.appendChild(document.createElement("br"));
+            if (parts[i]) element.appendChild(document.createTextNode(parts[i]));
+        }
+    }
+
+    /**
      * Strip content from template HTML for cloning new instances.
      * - Removes text content
      * - Strips instance IDs
@@ -557,7 +570,7 @@
             const data = JSON.parse(content) as { type?: string };
 
             if (data.type === "text") {
-                element.textContent = (data as { type: "text"; value: string }).value;
+                setTextWithBreaks(element, (data as { type: "text"; value: string }).value);
                 return element;
             } else if (data.type === "html") {
                 element.innerHTML = (data as { type: "html"; value: string }).value;
@@ -611,7 +624,7 @@
             } else if (type === "text") {
                 const textData = data as { value?: string };
                 if (textData.value !== undefined) {
-                    element.textContent = textData.value;
+                    setTextWithBreaks(element, textData.value);
                 }
             } else if (type === "html") {
                 const htmlData = data as { value?: string };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -434,7 +434,8 @@
      */
     function scanEditableElements(): Map<string, EditableElementInfo[]> {
         const elements = new Map<string, EditableElementInfo[]>();
-        const selector = "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
+        const selector =
+            "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
         document.querySelectorAll<HTMLElement>(selector).forEach((element) => {
             const info = getEditableInfo(element);
             if (info) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,13 +137,13 @@ export interface BatchUpdateResponse {
 /**
  * Editable element types
  */
-export type EditableType = "text" | "html" | "image" | "link";
+export type EditableType = "text" | "html" | "image" | "link" | "href";
 
 /**
  * CSS selector for all editable elements
  */
 export const EDITABLE_SELECTOR =
-    "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link]";
+    "[data-scms-text], [data-scms-html], [data-scms-image], [data-scms-link], [data-scms-href]";
 
 /**
  * Placeholder image for new template instances (SVG data URI)
@@ -206,7 +206,18 @@ export interface LinkContentData extends BaseContentData {
     value: string;
 }
 
-export type ContentData = TextContentData | HtmlContentData | ImageContentData | LinkContentData;
+export interface HrefContentData extends BaseContentData {
+    type: "href";
+    href: string;
+    target: string;
+}
+
+export type ContentData =
+    | TextContentData
+    | HtmlContentData
+    | ImageContentData
+    | LinkContentData
+    | HrefContentData;
 
 /**
  * Template instance info for repeating content blocks

--- a/tests/browser/desktop/content-parsing.test.ts
+++ b/tests/browser/desktop/content-parsing.test.ts
@@ -47,6 +47,26 @@ beforeAll(async () => {
         }),
     );
 
+    // Text with line breaks
+    await setContent(
+        appId,
+        "test-line-breaks",
+        JSON.stringify({
+            type: "text",
+            value: "First line\nSecond line\nThird line",
+        }),
+    );
+
+    // Text with special characters that could cause XSS if mishandled
+    await setContent(
+        appId,
+        "test-text-escaping",
+        JSON.stringify({
+            type: "text",
+            value: "Hello <script>alert(1)</script>\n&amp; goodbye",
+        }),
+    );
+
     await initializeSDK({ appId });
 });
 
@@ -89,4 +109,86 @@ test("link content has proper attributes parsed from type:link format", async ()
 
     // The display text should be the value, not any JSON
     expect(link.textContent).toBe("Parsed Link Text");
+});
+
+test("text content with line breaks renders <br> tags in DOM", async () => {
+    const el = document.querySelector('[data-scms-text="test-line-breaks"]') as HTMLElement;
+
+    // \n in stored value should become <br> elements in the DOM
+    const brs = el.querySelectorAll("br");
+    expect(brs.length).toBe(2);
+
+    // Text nodes should contain the line content
+    expect(el.textContent).toBe("First lineSecond lineThird line");
+});
+
+test("text content with <br> line breaks round-trips correctly", async () => {
+    const el = document.querySelector('[data-scms-text="test-line-breaks"]') as HTMLElement;
+
+    // Simulate Shift+Enter which inserts <br> tags
+    el.innerHTML = "Edited first<br>Edited second";
+
+    // Use the same serialization the SDK uses (imported indirectly via DOM clone)
+    const clone = document.createElement("div");
+    clone.innerHTML = el.innerHTML;
+    clone.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
+    const serialized = clone.textContent || "";
+
+    expect(serialized).toBe("Edited first\nEdited second");
+});
+
+test("text content with <div> line breaks (Chrome contenteditable) round-trips correctly", async () => {
+    const el = document.querySelector('[data-scms-text="test-line-breaks"]') as HTMLElement;
+
+    // Chrome wraps each Enter in a <div>; empty lines get <div><br></div>
+    el.innerHTML = "First line<div>Second line</div><div>Third line</div>";
+
+    // Simulate the SDK's readTextWithBreaks logic
+    const clone = document.createElement("div");
+    clone.innerHTML = el.innerHTML;
+    clone.querySelectorAll("div").forEach((div) => {
+        div.before(document.createTextNode("\n"));
+        if (div.childNodes.length === 1 && div.firstChild instanceof HTMLBRElement) {
+            div.firstChild.remove();
+        }
+        while (div.firstChild) div.before(div.firstChild);
+        div.remove();
+    });
+    clone.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
+    const serialized = clone.textContent || "";
+
+    expect(serialized).toBe("First line\nSecond line\nThird line");
+});
+
+test("empty lines from contenteditable <div><br></div> are preserved", async () => {
+    const el = document.querySelector('[data-scms-text="test-line-breaks"]') as HTMLElement;
+
+    // Simulate the user's exact scenario: text, empty line, items, empty line, more items
+    el.innerHTML = "Hello<div><br></div><div>1</div><div>2</div><div><br></div><div>World</div>";
+
+    const clone = document.createElement("div");
+    clone.innerHTML = el.innerHTML;
+    clone.querySelectorAll("div").forEach((div) => {
+        div.before(document.createTextNode("\n"));
+        if (div.childNodes.length === 1 && div.firstChild instanceof HTMLBRElement) {
+            div.firstChild.remove();
+        }
+        while (div.firstChild) div.before(div.firstChild);
+        div.remove();
+    });
+    clone.querySelectorAll("br").forEach((br) => br.replaceWith("\n"));
+    const serialized = clone.textContent || "";
+
+    expect(serialized).toBe("Hello\n\n1\n2\n\nWorld");
+});
+
+test("text content escapes HTML entities and is not vulnerable to XSS", async () => {
+    const el = document.querySelector('[data-scms-text="test-text-escaping"]') as HTMLElement;
+
+    // The <script> tag in the stored value must NOT be rendered as a real element
+    expect(el.querySelector("script")).toBeNull();
+
+    // The raw text should be visible as-is
+    expect(el.textContent).toContain("<script>alert(1)</script>");
+    expect(el.textContent).toContain("&amp; goodbye");
 });

--- a/tests/browser/desktop/drafts/persistence.test.ts
+++ b/tests/browser/desktop/drafts/persistence.test.ts
@@ -9,6 +9,7 @@ import { test, expect, beforeAll, afterEach } from "vitest";
 import {
     initializeSDK,
     waitForCondition,
+    setElementContent,
     setupTestHelpers,
     getController,
 } from "~/@browser-support/sdk-helpers.js";
@@ -55,8 +56,7 @@ async function editContent(element: HTMLElement, newContent: string): Promise<vo
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    element.innerHTML = newContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, newContent);
 
     await new Promise((r) => setTimeout(r, 100));
 }
@@ -77,8 +77,7 @@ test("draft is saved to localStorage when content changes", async () => {
     expect(Object.keys(draft.content).length).toBeGreaterThan(0);
 
     // Reset content
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("draft contains the edited content", async () => {
@@ -97,8 +96,7 @@ test("draft contains the edited content", async () => {
     expect(hasContent).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("draft is removed when content matches original", async () => {
@@ -111,9 +109,13 @@ test("draft is removed when content matches original", async () => {
     // Verify draft exists
     expect(localStorage.getItem(getDraftKey())).not.toBeNull();
 
-    // Revert to original
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    // Revert to original content
+    setElementContent(element, originalContent);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Stop editing so content syncs
+    document.body.click();
+    await waitForCondition(() => !element.classList.contains("streamlined-editing"));
     await new Promise((r) => setTimeout(r, 100));
 
     // Draft should be removed
@@ -136,9 +138,13 @@ test("toolbar hasChanges reflects unsaved state", async () => {
     // hasChanges should be true
     expect(toolbar!.hasChanges).toBe(true);
 
-    // Revert
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    // Revert to original
+    setElementContent(element, originalContent);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Stop editing so content syncs
+    document.body.click();
+    await waitForCondition(() => !element.classList.contains("streamlined-editing"));
     await new Promise((r) => setTimeout(r, 100));
 
     // hasChanges should be false
@@ -159,8 +165,7 @@ test("draft structure includes content and deleted arrays", async () => {
     expect(Array.isArray(draft.deleted)).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("multiple edits update the same draft", async () => {
@@ -172,8 +177,7 @@ test("multiple edits update the same draft", async () => {
     const firstDraft = localStorage.getItem(getDraftKey());
 
     // Second edit
-    element.innerHTML = "Second edit";
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, "Second edit");
     await new Promise((r) => setTimeout(r, 100));
 
     const secondDraft = localStorage.getItem(getDraftKey());
@@ -187,8 +191,7 @@ test("multiple edits update the same draft", async () => {
     expect(hasSecondEdit).toBe(true);
 
     // Reset
-    element.innerHTML = originalContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, originalContent);
 });
 
 test("invalid draft JSON in localStorage is handled gracefully", async () => {

--- a/tests/browser/desktop/editing-basic.test.ts
+++ b/tests/browser/desktop/editing-basic.test.ts
@@ -7,6 +7,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 
@@ -44,11 +45,8 @@ test("user can edit and save content", async () => {
         await waitForCondition(() => testTitle.classList.contains("streamlined-editing"));
     }
 
-    // Edit the content - use innerHTML for html-type elements
-    testTitle.innerHTML = "Test Edit - Browser Test";
-
-    // Trigger input event to notify SDK of changes
-    testTitle.dispatchEvent(new Event("input", { bubbles: true }));
+    // Edit the content
+    setElementContent(testTitle, "Test Edit - Browser Test");
 
     // Click save button (helper waits for Lit re-render)
     await clickToolbarButton("Save");

--- a/tests/browser/desktop/editing/empty-placeholder.test.ts
+++ b/tests/browser/desktop/editing/empty-placeholder.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests that the "Click to edit" placeholder appears whenever an editable
+ * element has no visible content, so the element retains a clickable area.
+ *
+ * Regression test for https://github.com/streamlinedcms/client-sdk/issues/85
+ *
+ * Covers all four editable types and exercises the cases where the DOM is
+ * not literally `:empty` after deletion: stray <br> from contenteditable,
+ * Tiptap's empty <p>/<span> wrappers, etc. The acceptance criterion is the
+ * presence of the `streamlined-empty` class (which the placeholder CSS rule
+ * keys off) — that's the same signal the user would see in the rendered UI.
+ */
+
+import { test, expect, beforeAll, afterEach } from "vitest";
+import { userEvent } from "@vitest/browser/context";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+
+let appId: string;
+
+function getEl(attr: string, id: string): HTMLElement {
+    return document.querySelector(`[${attr}="${id}"]`) as HTMLElement;
+}
+
+function selectAll(el: HTMLElement): void {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+async function deleteAll(el: HTMLElement): Promise<void> {
+    selectAll(el);
+    await userEvent.keyboard("{Delete}");
+    // Tiptap commits via debounced onUpdate; give it a tick.
+    await new Promise((r) => setTimeout(r, 100));
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    appId = generateTestAppId();
+    await initializeSDK({ appId });
+});
+
+afterEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+// ---------------------------------------------------------------------------
+// Initial state — non-empty elements should NOT have the empty class
+// ---------------------------------------------------------------------------
+
+test("non-empty elements do not have streamlined-empty on init", () => {
+    expect(getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"))
+        .toBe(false);
+    expect(
+        getEl("data-scms-html", "placeholder-inline-html").classList.contains("streamlined-empty"),
+    ).toBe(false);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-text: contenteditable leaves a stray <br>
+// ---------------------------------------------------------------------------
+
+test("text element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-text", "placeholder-text");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-html: Tiptap leaves <p></p> / <span><br></span>
+// ---------------------------------------------------------------------------
+
+test("block html element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-html", "placeholder-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+test("inline html element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-html", "placeholder-inline-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// data-scms-link: also Tiptap-backed
+// ---------------------------------------------------------------------------
+
+test("link element gets streamlined-empty after deleting all characters", async () => {
+    const el = getEl("data-scms-link", "placeholder-link");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// Re-typing removes the empty class
+// ---------------------------------------------------------------------------
+
+test("typing into an empty element clears streamlined-empty", async () => {
+    const el = getEl("data-scms-text", "placeholder-text");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+
+    await userEvent.keyboard("Hello");
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(el.classList.contains("streamlined-empty")).toBe(false);
+});
+
+test("typing then re-deleting toggles streamlined-empty back on", async () => {
+    const el = getEl("data-scms-html", "placeholder-html");
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+
+    await userEvent.keyboard("More");
+    await new Promise((r) => setTimeout(r, 100));
+    expect(el.classList.contains("streamlined-empty")).toBe(false);
+
+    await deleteAll(el);
+    expect(el.classList.contains("streamlined-empty")).toBe(true);
+});

--- a/tests/browser/desktop/editing/empty-placeholder.test.ts
+++ b/tests/browser/desktop/editing/empty-placeholder.test.ts
@@ -57,12 +57,15 @@ afterEach(async () => {
 // ---------------------------------------------------------------------------
 
 test("non-empty elements do not have streamlined-empty on init", () => {
-    expect(getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"))
-        .toBe(false);
-    expect(getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"))
-        .toBe(false);
-    expect(getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"))
-        .toBe(false);
+    expect(
+        getEl("data-scms-text", "placeholder-text").classList.contains("streamlined-empty"),
+    ).toBe(false);
+    expect(
+        getEl("data-scms-html", "placeholder-html").classList.contains("streamlined-empty"),
+    ).toBe(false);
+    expect(
+        getEl("data-scms-link", "placeholder-link").classList.contains("streamlined-empty"),
+    ).toBe(false);
     expect(
         getEl("data-scms-html", "placeholder-inline-html").classList.contains("streamlined-empty"),
     ).toBe(false);

--- a/tests/browser/desktop/editing/first-click-caret.test.ts
+++ b/tests/browser/desktop/editing/first-click-caret.test.ts
@@ -1,0 +1,122 @@
+/**
+ * First-click caret placement tests
+ *
+ * Tiptap editors must receive focus and a ProseMirror selection on the
+ * FIRST click — users should not have to click twice to get a caret.
+ *
+ * These tests guard against regression of a bug where attach() created a
+ * new Tiptap editor but never called editor.commands.focus() on it, so
+ * the caret only appeared on the second click (which hit the reuse
+ * branch that does focus the editor).
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { FormattingToolbar } from "~/src/components/rich-text-editor.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getFormattingToolbar(): FormattingToolbar | null {
+    return document.querySelector("scms-formatting-toolbar") as FormattingToolbar | null;
+}
+
+function getParagraph(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-paragraph"]') as HTMLElement;
+}
+
+function getTitle(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
+}
+
+test("first click on an HTML element focuses the Tiptap editor", async () => {
+    const el = getTitle();
+
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    expect(toolbar).not.toBeNull();
+    expect(toolbar!.editor).not.toBeNull();
+
+    // Tiptap's focus command defers view.focus() via requestAnimationFrame,
+    // so isFocused flips async. Wait briefly for it to settle.
+    await waitForCondition(() => toolbar!.editor!.isFocused === true);
+
+    expect(toolbar!.editor!.isFocused).toBe(true);
+    expect(toolbar!.editor!.view.hasFocus()).toBe(true);
+
+    const sel = window.getSelection();
+    expect(sel).not.toBeNull();
+    expect(sel!.rangeCount).toBeGreaterThan(0);
+});
+
+test("first click places the caret at the click coordinates", async () => {
+    const el = getParagraph();
+    const rect = el.getBoundingClientRect();
+
+    // Aim for a point ~75% across the text horizontally so the resulting
+    // selection position is clearly distinguishable from pos 0 and pos end.
+    const clickX = Math.round(rect.left + rect.width * 0.75);
+    const clickY = Math.round(rect.top + rect.height / 2);
+
+    el.dispatchEvent(
+        new MouseEvent("click", {
+            bubbles: true,
+            cancelable: true,
+            clientX: clickX,
+            clientY: clickY,
+        }),
+    );
+
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    const editor = toolbar!.editor!;
+    await waitForCondition(() => editor.isFocused === true);
+    expect(editor.isFocused).toBe(true);
+
+    const expected = editor.view.posAtCoords({ left: clickX, top: clickY });
+    expect(expected).not.toBeNull();
+
+    const actualFrom = editor.view.state.selection.from;
+    // Allow ±1 for boundary ambiguity between adjacent positions.
+    expect(Math.abs(actualFrom - expected!.pos)).toBeLessThanOrEqual(1);
+});
+
+test("keyboard navigation to next editable still focuses (fallback path)", async () => {
+    const first = getTitle();
+    const second = getParagraph();
+
+    first.click();
+    await waitForCondition(() => first.classList.contains("streamlined-editing"));
+
+    // Tab handler is attached to the editable itself (see editing-manager.ts),
+    // so dispatch on the first element — navigateToNextEditable then calls
+    // startEditing on `second` WITHOUT click coords, exercising the fallback.
+    first.dispatchEvent(
+        new KeyboardEvent("keydown", {
+            key: "Tab",
+            bubbles: true,
+            cancelable: true,
+        }),
+    );
+
+    await waitForCondition(() => second.classList.contains("streamlined-editing"));
+
+    const toolbar = getFormattingToolbar();
+    expect(toolbar!.editor).not.toBeNull();
+    await waitForCondition(() => toolbar!.editor!.isFocused === true);
+    expect(toolbar!.editor!.isFocused).toBe(true);
+});

--- a/tests/browser/desktop/editing/href-elements.test.ts
+++ b/tests/browser/desktop/editing/href-elements.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Href element editing tests
+ *
+ * Covers the non-content href editable: selection, toolbar controls, modal
+ * editing, and inner-HTML preservation across apply cycles. Also covers the
+ * scanner's warnings for invalid usage (multiple data-scms-* on one element,
+ * data-scms-href on a non-anchor).
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    waitForSelector,
+    clickToolbarButton,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+import type { LinkEditorModal } from "~/src/components/link-editor-modal.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getToolbar(): Toolbar | null {
+    return document.querySelector("scms-toolbar") as Toolbar | null;
+}
+
+function getHrefElement(): HTMLAnchorElement {
+    return document.querySelector('[data-scms-href="test-href"]') as HTMLAnchorElement;
+}
+
+function getHrefEditorModal(): LinkEditorModal | null {
+    return document.querySelector("scms-link-editor-modal") as LinkEditorModal | null;
+}
+
+test("href element is registered as editable", () => {
+    const href = getHrefElement();
+    expect(href.classList.contains("streamlined-editable")).toBe(true);
+});
+
+test("clicking href element selects it with type 'href'", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    expect(toolbar?.activeElementType).toBe("href");
+});
+
+test("href element has no 'Click to edit' placeholder even if empty inside", () => {
+    const href = getHrefElement();
+    // An href-type element should never carry streamlined-empty (that would show
+    // the placeholder inside developer-authored markup).
+    expect(href.classList.contains("streamlined-empty")).toBe(false);
+});
+
+test("toolbar shows Edit Link and Go to Link buttons for href element", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const buttons = toolbar!.shadowRoot!.querySelectorAll("button");
+    const labels = Array.from(buttons).map((b) => b.textContent?.trim() ?? "");
+
+    expect(labels.some((l) => l.includes("Edit Link"))).toBe(true);
+    expect(labels.some((l) => l.includes("Go to Link"))).toBe(true);
+});
+
+test("toolbar does NOT show View Source for href element", async () => {
+    const href = getHrefElement();
+    const toolbar = getToolbar();
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const buttons = toolbar!.shadowRoot!.querySelectorAll("button");
+    const hasViewSource = Array.from(buttons).some((b) =>
+        b.textContent?.trim().includes("View Source"),
+    );
+    expect(hasViewSource).toBe(false);
+});
+
+test("editing href via modal updates href and target but preserves inner HTML", async () => {
+    const href = getHrefElement();
+    const originalInnerHTML = href.innerHTML;
+
+    href.click();
+    await waitForCondition(() => href.classList.contains("streamlined-editing"));
+
+    const clicked = await clickToolbarButton("Edit Link");
+    expect(clicked).toBe(true);
+
+    await waitForSelector("scms-link-editor-modal");
+    const modal = getHrefEditorModal()!;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    const urlInput = shadowRoot.querySelector('input[type="url"]') as HTMLInputElement;
+    urlInput.value = "https://example.com/updated";
+    urlInput.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const targetSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
+    targetSelect.value = "_blank";
+    targetSelect.dispatchEvent(new Event("change", { bubbles: true }));
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    const applyBtn = Array.from(shadowRoot.querySelectorAll("button")).find(
+        (b) => b.textContent?.trim() === "Apply",
+    ) as HTMLButtonElement;
+    applyBtn.click();
+
+    await waitForCondition(() => getHrefEditorModal() === null);
+
+    // Attributes changed
+    expect(href.getAttribute("href")).toBe("https://example.com/updated");
+    expect(href.target).toBe("_blank");
+    // Inner HTML intact (icon + span still present)
+    expect(href.innerHTML).toBe(originalInnerHTML);
+    expect(href.querySelector('[data-testid="href-icon"]')).not.toBeNull();
+    expect(href.querySelector('[data-testid="href-label"]')).not.toBeNull();
+});
+
+test("href with both data-scms-href and data-scms-text skips href and registers text", () => {
+    // Scanner warns and registers only the first matching type (text, since it's
+    // earlier in the priority list). The href attribute is ignored.
+    const element = document.querySelector(
+        '[data-scms-href="test-href-conflict"]',
+    ) as HTMLAnchorElement;
+    expect(element).not.toBeNull();
+    // Still gets the editable class because data-scms-text registered it.
+    expect(element.classList.contains("streamlined-editable")).toBe(true);
+});
+
+test("data-scms-href on a non-anchor element is skipped", () => {
+    const bad = document.querySelector(
+        '[data-scms-href="test-href-nonanchor"]',
+    ) as HTMLElement;
+    expect(bad).not.toBeNull();
+    // Not registered, so no editable class.
+    expect(bad.classList.contains("streamlined-editable")).toBe(false);
+});

--- a/tests/browser/desktop/editing/href-elements.test.ts
+++ b/tests/browser/desktop/editing/href-elements.test.ts
@@ -145,9 +145,7 @@ test("href with both data-scms-href and data-scms-text skips href and registers 
 });
 
 test("data-scms-href on a non-anchor element is skipped", () => {
-    const bad = document.querySelector(
-        '[data-scms-href="test-href-nonanchor"]',
-    ) as HTMLElement;
+    const bad = document.querySelector('[data-scms-href="test-href-nonanchor"]') as HTMLElement;
     expect(bad).not.toBeNull();
     // Not registered, so no editable class.
     expect(bad.classList.contains("streamlined-editable")).toBe(false);

--- a/tests/browser/desktop/editing/outer-editable-button.test.ts
+++ b/tests/browser/desktop/editing/outer-editable-button.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Outer-editable navigation button tests
+ *
+ * When a nested editable fills its parent's interior (e.g. data-scms-html as
+ * the immediate child of data-scms-href), the outer editable can't be clicked
+ * directly. The toolbar exposes a "select outer" button for these cases.
+ */
+
+import { test, expect, beforeAll, beforeEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+} from "~/@browser-support/sdk-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    await initializeSDK();
+});
+
+beforeEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getWrapperHref(): HTMLAnchorElement {
+    return document.querySelector('[data-scms-href="test-href-wrapper"]') as HTMLAnchorElement;
+}
+
+function getWrappedHtml(): HTMLElement {
+    return document.querySelector('[data-scms-html="test-wrapped-html"]') as HTMLElement;
+}
+
+function findButton(text: string): HTMLButtonElement | null {
+    const toolbar = getToolbar();
+    const buttons = toolbar.shadowRoot!.querySelectorAll("button");
+    for (const btn of buttons) {
+        const label = btn.getAttribute("aria-label") ?? btn.textContent?.trim() ?? "";
+        if (label.includes(text)) return btn as HTMLButtonElement;
+    }
+    return null;
+}
+
+test("outer-select button is hidden when there's no outer editable", async () => {
+    // test-link has no editable ancestor
+    const link = document.querySelector('[data-scms-link="test-link"]') as HTMLAnchorElement;
+    link.click();
+    await waitForCondition(() => link.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getToolbar().hasOuterEditable).toBe(false);
+    expect(findButton("Select outer element")).toBeNull();
+});
+
+test("outer-select button is shown when selection has an editable ancestor", async () => {
+    const innerHtml = getWrappedHtml();
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getToolbar().hasOuterEditable).toBe(true);
+    expect(findButton("Select outer element")).not.toBeNull();
+});
+
+test("clicking outer-select button selects the editable ancestor", async () => {
+    const innerHtml = getWrappedHtml();
+    const outerHref = getWrapperHref();
+
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    const button = findButton("Select outer element");
+    expect(button).not.toBeNull();
+    button!.click();
+
+    await waitForCondition(() => outerHref.classList.contains("streamlined-editing"));
+    expect(getToolbar().activeElementType).toBe("href");
+    // The inner html is no longer the active editing target.
+    expect(innerHtml.classList.contains("streamlined-editing")).toBe(false);
+});
+
+test("outer-select button is hidden again at the top of the chain", async () => {
+    const innerHtml = getWrappedHtml();
+    const outerHref = getWrapperHref();
+
+    innerHtml.click();
+    await waitForCondition(() => innerHtml.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    findButton("Select outer element")!.click();
+    await waitForCondition(() => outerHref.classList.contains("streamlined-editing"));
+
+    await new Promise((r) => setTimeout(r, 50));
+    // href has no editable ancestor, so the button disappears.
+    expect(getToolbar().hasOuterEditable).toBe(false);
+    expect(findButton("Select outer element")).toBeNull();
+});

--- a/tests/browser/desktop/editing/text-elements.test.ts
+++ b/tests/browser/desktop/editing/text-elements.test.ts
@@ -138,7 +138,7 @@ test("toolbar shows Reset button for text elements", async () => {
     expect(holdButton).not.toBeNull();
 });
 
-test("text elements do not show Edit Content button", async () => {
+test("text elements do not show View Source button", async () => {
     const element = getTextElement();
     const toolbar = getToolbar();
 
@@ -150,12 +150,12 @@ test("text elements do not show Edit Content button", async () => {
 
     let hasEditHtmlButton = false;
     for (const btn of buttons) {
-        if (btn.textContent?.includes("Edit Content")) {
+        if (btn.textContent?.includes("View Source")) {
             hasEditHtmlButton = true;
             break;
         }
     }
 
-    // Text elements should NOT have Edit Content button
+    // Text elements should NOT have View Source button
     expect(hasEditHtmlButton).toBe(false);
 });

--- a/tests/browser/desktop/editing/text-elements.test.ts
+++ b/tests/browser/desktop/editing/text-elements.test.ts
@@ -138,7 +138,7 @@ test("toolbar shows Reset button for text elements", async () => {
     expect(holdButton).not.toBeNull();
 });
 
-test("text elements do not show Edit HTML button", async () => {
+test("text elements do not show Edit Content button", async () => {
     const element = getTextElement();
     const toolbar = getToolbar();
 
@@ -150,12 +150,12 @@ test("text elements do not show Edit HTML button", async () => {
 
     let hasEditHtmlButton = false;
     for (const btn of buttons) {
-        if (btn.textContent?.includes("Edit HTML")) {
+        if (btn.textContent?.includes("Edit Content")) {
             hasEditHtmlButton = true;
             break;
         }
     }
 
-    // Text elements should NOT have Edit HTML button
+    // Text elements should NOT have Edit Content button
     expect(hasEditHtmlButton).toBe(false);
 });

--- a/tests/browser/desktop/editing/text-line-breaks-keyboard.test.ts
+++ b/tests/browser/desktop/editing/text-line-breaks-keyboard.test.ts
@@ -53,7 +53,9 @@ function dumpDOM(el: HTMLElement, label: string): void {
     for (let i = 0; i < el.childNodes.length; i++) {
         const n = el.childNodes[i];
         if (n.nodeType === Node.ELEMENT_NODE) {
-            console.log(`  [${i}] <${(n as Element).tagName.toLowerCase()}> innerHTML=${JSON.stringify((n as Element).innerHTML)}`);
+            console.log(
+                `  [${i}] <${(n as Element).tagName.toLowerCase()}> innerHTML=${JSON.stringify((n as Element).innerHTML)}`,
+            );
         } else {
             console.log(`  [${i}] text: ${JSON.stringify(n.textContent)}`);
         }
@@ -65,11 +67,7 @@ beforeAll(async () => {
     const { generateTestAppId } = await import("~/@browser-support/sdk-helpers.js");
     appId = generateTestAppId();
 
-    await setContent(
-        appId,
-        "kb-test",
-        JSON.stringify({ type: "text", value: "Initial text" }),
-    );
+    await setContent(appId, "kb-test", JSON.stringify({ type: "text", value: "Initial text" }));
 
     await initializeSDK({ appId });
 });
@@ -455,10 +453,10 @@ async function restoreAndEdit(storedValue: string): Promise<HTMLElement> {
 
     // Simulate restore: write via the SDK's own writeTextWithBreaks path
     // by setting currentContent and syncing
-    const state = (getController() as unknown as {
+    const state = getController() as unknown as {
         state: { currentContent: Map<string, string>; originalContent: Map<string, string> };
         contentManager: { syncAllElementsFromContent: (key: string) => void };
-    });
+    };
     const json = JSON.stringify({ type: "text", value: storedValue });
     state.state.currentContent.set("kb-test", json);
     state.state.originalContent.set("kb-test", json);

--- a/tests/browser/desktop/editing/text-line-breaks-keyboard.test.ts
+++ b/tests/browser/desktop/editing/text-line-breaks-keyboard.test.ts
@@ -1,0 +1,942 @@
+/**
+ * Text line break tests using real keyboard events
+ *
+ * These tests use Vitest's userEvent (backed by Playwright) to simulate
+ * actual keypresses in contenteditable text elements. This reveals the
+ * real DOM structures the browser produces, which may differ from
+ * manually constructed innerHTML.
+ */
+
+import { test, expect, beforeAll, afterEach } from "vitest";
+import { userEvent } from "@vitest/browser/context";
+import {
+    initializeSDK,
+    waitForCondition,
+    clickToolbarButton,
+    setupTestHelpers,
+    getController,
+} from "~/@browser-support/sdk-helpers.js";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+let appId: string;
+
+function getStoredValue(key: string): string {
+    const state = (getController() as unknown as { state: { currentContent: Map<string, string> } })
+        .state;
+    const raw = state.currentContent.get(key);
+    if (!raw) throw new Error(`No currentContent for key "${key}"`);
+    return (JSON.parse(raw) as { value: string }).value;
+}
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getElement(): HTMLElement {
+    return document.querySelector('[data-scms-text="kb-test"]') as HTMLElement;
+}
+
+/** Select all content within a contenteditable element */
+function selectAll(el: HTMLElement): void {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+}
+
+/** Log the DOM structure for debugging */
+function dumpDOM(el: HTMLElement, label: string): void {
+    console.log(`[${label}] innerHTML: ${JSON.stringify(el.innerHTML)}`);
+    console.log(`[${label}] childNodes: ${el.childNodes.length}`);
+    for (let i = 0; i < el.childNodes.length; i++) {
+        const n = el.childNodes[i];
+        if (n.nodeType === Node.ELEMENT_NODE) {
+            console.log(`  [${i}] <${(n as Element).tagName.toLowerCase()}> innerHTML=${JSON.stringify((n as Element).innerHTML)}`);
+        } else {
+            console.log(`  [${i}] text: ${JSON.stringify(n.textContent)}`);
+        }
+    }
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    const { generateTestAppId } = await import("~/@browser-support/sdk-helpers.js");
+    appId = generateTestAppId();
+
+    await setContent(
+        appId,
+        "kb-test",
+        JSON.stringify({ type: "text", value: "Initial text" }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+afterEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+    // Reset element to clean state for next test
+    const el = getElement();
+    el.textContent = "Reset";
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+});
+
+// ---------------------------------------------------------------------------
+// Basic typing
+// ---------------------------------------------------------------------------
+
+test("type simple text without Enter", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Select all and replace
+    await selectAll(el);
+    await userEvent.keyboard("Hello world");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "simple text");
+    const value = getStoredValue("kb-test");
+    console.log(`[simple text] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Hello world");
+});
+
+// ---------------------------------------------------------------------------
+// Single Enter
+// ---------------------------------------------------------------------------
+
+test("type text, press Enter, type more text", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Line one");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Line two");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "single Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[single Enter] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Line one\nLine two");
+});
+
+// ---------------------------------------------------------------------------
+// Multiple Enters
+// ---------------------------------------------------------------------------
+
+test("type text, press Enter twice (empty line), type more", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Before");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("After");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "double Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[double Enter] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Before\n\nAfter");
+});
+
+test("three lines of text with single Enters between", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("First");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Second");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Third");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "three lines");
+    const value = getStoredValue("kb-test");
+    console.log(`[three lines] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("First\nSecond\nThird");
+});
+
+// ---------------------------------------------------------------------------
+// Shift+Enter (should produce <br> instead of <div>)
+// ---------------------------------------------------------------------------
+
+test("Shift+Enter produces a line break within the same block", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Soft line one");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    await userEvent.keyboard("Soft line two");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "Shift+Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[Shift+Enter] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Soft line one\nSoft line two");
+});
+
+// ---------------------------------------------------------------------------
+// Mixed Enter and Shift+Enter
+// ---------------------------------------------------------------------------
+
+test("mixing Enter and Shift+Enter", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("A");
+    await userEvent.keyboard("{Shift>}{Enter}{/Shift}");
+    await userEvent.keyboard("B");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("C");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "mixed Enter/Shift+Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[mixed Enter/Shift+Enter] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("A\nB\nC");
+});
+
+// ---------------------------------------------------------------------------
+// Enter at the beginning (leading empty line)
+// ---------------------------------------------------------------------------
+
+test("pressing Enter at the start creates a leading empty line", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("After empty");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "leading Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[leading Enter] serialized: ${JSON.stringify(value)}`);
+
+    // Could be "\nAfter empty" or "\n\nAfter empty" depending on browser behavior
+    // with the initial selection replacement
+    console.log(`[leading Enter] expected contains: "After empty" with leading newline(s)`);
+    expect(value).toContain("After empty");
+    expect(value).toMatch(/^\n/); // should start with at least one newline
+});
+
+// ---------------------------------------------------------------------------
+// Trailing Enter (cursor at end, press Enter)
+// ---------------------------------------------------------------------------
+
+test("pressing Enter at the end creates a trailing empty line", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Content");
+    await userEvent.keyboard("{Enter}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "trailing Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[trailing Enter] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toMatch(/^Content\n/);
+});
+
+// ---------------------------------------------------------------------------
+// Many rapid Enters (empty lines)
+// ---------------------------------------------------------------------------
+
+test("pressing Enter 5 times creates multiple empty lines", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Top");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Bottom");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "5 Enters");
+    const value = getStoredValue("kb-test");
+    console.log(`[5 Enters] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Top\n\n\n\n\nBottom");
+});
+
+// ---------------------------------------------------------------------------
+// Issue #81 scenario: multi-line text with gaps
+// ---------------------------------------------------------------------------
+
+test("issue #81: type paragraph, blank lines, numbered items, blank line, word, blank line, more numbers", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Paragraph text here.");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("1");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("2");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("3");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Something");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("4");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("5");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "issue #81");
+    const value = getStoredValue("kb-test");
+    console.log(`[issue #81] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Paragraph text here.\n\n1\n2\n3\n\nSomething\n\n4\n5");
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: type → save → re-read serialized value
+// ---------------------------------------------------------------------------
+
+test("round-trip: type multi-line, save, verify value survives", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Alpha");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Bravo");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Charlie");
+    await new Promise((r) => setTimeout(r, 100));
+
+    const beforeSave = getStoredValue("kb-test");
+    console.log(`[round-trip] before save: ${JSON.stringify(beforeSave)}`);
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    const afterSave = getStoredValue("kb-test");
+    console.log(`[round-trip] after save: ${JSON.stringify(afterSave)}`);
+
+    expect(afterSave).toBe(beforeSave);
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: type → save → deselect → re-select → verify re-read
+// ---------------------------------------------------------------------------
+
+test("round-trip: value is consistent after deselect and re-select", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("X");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Y");
+    await new Promise((r) => setTimeout(r, 100));
+
+    const firstRead = getStoredValue("kb-test");
+    console.log(`[re-select] first read: ${JSON.stringify(firstRead)}`);
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    // Deselect
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    dumpDOM(el, "after deselect");
+    console.log(`[re-select] after deselect: ${JSON.stringify(getStoredValue("kb-test"))}`);
+
+    // Re-select
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "after re-select");
+    const afterReselect = getStoredValue("kb-test");
+    console.log(`[re-select] after re-select: ${JSON.stringify(afterReselect)}`);
+
+    expect(afterReselect).toBe(firstRead);
+});
+
+// ---------------------------------------------------------------------------
+// Double round-trip: type → save → deselect → re-select → save again
+// ---------------------------------------------------------------------------
+
+test("double round-trip: edit, save, re-edit with more lines, save again", async () => {
+    const el = getElement();
+
+    // First edit
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    await selectAll(el);
+    await userEvent.keyboard("First");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Second");
+    await new Promise((r) => setTimeout(r, 100));
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    const afterFirstSave = getStoredValue("kb-test");
+    console.log(`[double round-trip] after first save: ${JSON.stringify(afterFirstSave)}`);
+
+    // Deselect and re-select
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Move cursor to end and add more content
+    await userEvent.keyboard("{End}");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Third");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "double round-trip after 2nd edit");
+    const afterSecondEdit = getStoredValue("kb-test");
+    console.log(`[double round-trip] after second edit: ${JSON.stringify(afterSecondEdit)}`);
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    const afterSecondSave = getStoredValue("kb-test");
+    console.log(`[double round-trip] after second save: ${JSON.stringify(afterSecondSave)}`);
+
+    expect(afterSecondSave).toBe("First\nSecond\nThird");
+});
+
+// ===========================================================================
+// RESTORED CONTENT EDITING
+// These tests simulate what happens when the user edits content that was
+// previously saved and restored (DOM has <br> tags from writeTextWithBreaks).
+// ===========================================================================
+
+/**
+ * Helper: write content via SDK's restore path, then click to edit.
+ * This puts the element in the exact state a real page load would produce:
+ * <br> tags from writeTextWithBreaks, then contenteditable=true.
+ */
+async function restoreAndEdit(storedValue: string): Promise<HTMLElement> {
+    const el = getElement();
+
+    // Simulate restore: write via the SDK's own writeTextWithBreaks path
+    // by setting currentContent and syncing
+    const state = (getController() as unknown as {
+        state: { currentContent: Map<string, string>; originalContent: Map<string, string> };
+        contentManager: { syncAllElementsFromContent: (key: string) => void };
+    });
+    const json = JSON.stringify({ type: "text", value: storedValue });
+    state.state.currentContent.set("kb-test", json);
+    state.state.originalContent.set("kb-test", json);
+    state.contentManager.syncAllElementsFromContent("kb-test");
+
+    await new Promise((r) => setTimeout(r, 50));
+    dumpDOM(el, `restored "${storedValue.replace(/\n/g, "\\n")}"`);
+
+    // Now click to edit
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    return el;
+}
+
+// ---------------------------------------------------------------------------
+// Press Enter at the end of restored multi-line content
+// ---------------------------------------------------------------------------
+
+test("restored: press Enter at end of 2-line content adds a third line", async () => {
+    const el = await restoreAndEdit("Line one\nLine two");
+
+    // Move to end
+    await userEvent.keyboard("{End}");
+    // Ctrl+End to ensure we're at the very end (End might just go to end of last visible line)
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false); // collapse to end
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Line three");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored + Enter at end");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored + Enter at end] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Line one\nLine two\nLine three");
+});
+
+// ---------------------------------------------------------------------------
+// Press Enter in the middle of restored content
+// ---------------------------------------------------------------------------
+
+test("restored: press Enter in the middle of a line splits it", async () => {
+    const el = await restoreAndEdit("Hello world");
+
+    // Place cursor after "Hello" (position 5)
+    const textNode = el.firstChild!;
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(textNode, 5);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard("{Enter}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored + Enter in middle");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored + Enter in middle] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Hello\n world"); // &nbsp; normalized to regular space
+});
+
+// ---------------------------------------------------------------------------
+// Press Enter between two <br>-separated lines
+// ---------------------------------------------------------------------------
+
+test("restored: press Enter between two existing lines inserts empty line", async () => {
+    const el = await restoreAndEdit("AAA\nBBB");
+
+    // Place cursor at the start of "BBB" (the text node after <br>)
+    // DOM should be: "AAA" <br> "BBB"
+    dumpDOM(el, "before cursor placement");
+    const nodes = Array.from(el.childNodes);
+    // Find the text node containing "BBB"
+    let bbbNode: Node | null = null;
+    for (const n of nodes) {
+        if (n.nodeType === Node.TEXT_NODE && n.textContent?.includes("BBB")) {
+            bbbNode = n;
+            break;
+        }
+    }
+    console.log(`[between lines] BBB node found: ${!!bbbNode}`);
+
+    if (bbbNode) {
+        const sel = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(bbbNode, 0); // start of "BBB"
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+    }
+
+    await userEvent.keyboard("{Enter}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored + Enter between lines");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored + Enter between lines] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("AAA\n\nBBB"); // <br> before <div> is not double-counted
+});
+
+// ---------------------------------------------------------------------------
+// Type additional text at the end of a restored line (no Enter)
+// ---------------------------------------------------------------------------
+
+test("restored: typing at end of first line appends to it", async () => {
+    const el = await restoreAndEdit("First\nSecond");
+
+    // Place cursor at end of "First" (before the <br>)
+    const firstTextNode = el.firstChild!;
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(firstTextNode, firstTextNode.textContent!.length);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard(" added");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored + type at end of line");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored + type at end of line] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("First added\nSecond");
+});
+
+// ---------------------------------------------------------------------------
+// Full cycle: restore → edit in middle → save → restore → verify
+// ---------------------------------------------------------------------------
+
+test("restored: full cycle - restore, add line in middle, save, re-restore, verify", async () => {
+    const el = await restoreAndEdit("Top\nBottom");
+
+    // Place cursor at start of "Bottom"
+    const nodes = Array.from(el.childNodes);
+    let bottomNode: Node | null = null;
+    for (const n of nodes) {
+        if (n.nodeType === Node.TEXT_NODE && n.textContent?.includes("Bottom")) {
+            bottomNode = n;
+            break;
+        }
+    }
+
+    if (bottomNode) {
+        const sel = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(bottomNode, 0);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+    }
+
+    // Press Enter to push Bottom down, then type Middle
+    await userEvent.keyboard("{Enter}");
+    // The cursor should now be on a new line before "Bottom"
+    // We need to go up one line and type
+    await userEvent.keyboard("{ArrowUp}");
+    await userEvent.keyboard("Middle");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "full cycle - after middle insert");
+    const beforeSave = getStoredValue("kb-test");
+    console.log(`[full cycle] before save: ${JSON.stringify(beforeSave)}`);
+
+    // Save
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    // Deselect
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    dumpDOM(el, "full cycle - after save+deselect");
+    const afterSave = getStoredValue("kb-test");
+    console.log(`[full cycle] after save: ${JSON.stringify(afterSave)}`);
+
+    // Re-click to edit and verify the value reads back the same
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "full cycle - after re-select");
+    const afterReselect = getStoredValue("kb-test");
+    console.log(`[full cycle] after re-select: ${JSON.stringify(afterReselect)}`);
+
+    expect(afterSave).toBe(afterReselect);
+});
+
+// ---------------------------------------------------------------------------
+// Restore content with empty lines, then edit within
+// ---------------------------------------------------------------------------
+
+test("restored: content with empty lines, press Enter after first line", async () => {
+    const el = await restoreAndEdit("Alpha\n\nBravo");
+
+    // DOM should be: "Alpha" <br> <br> "Bravo" (or similar)
+    // Place cursor at end of "Alpha"
+    const firstTextNode = el.firstChild!;
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.setStart(firstTextNode, firstTextNode.textContent!.length);
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Inserted");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored empty lines + insert");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored empty lines + insert] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Alpha\nInserted\n\nBravo");
+});
+
+// ---------------------------------------------------------------------------
+// Delete across a <br> boundary (Backspace at start of second line)
+// ---------------------------------------------------------------------------
+
+test("restored: Backspace at start of second line joins the lines", async () => {
+    const el = await restoreAndEdit("Line A\nLine B");
+
+    // Place cursor at start of "Line B"
+    const nodes = Array.from(el.childNodes);
+    let lineBNode: Node | null = null;
+    for (const n of nodes) {
+        if (n.nodeType === Node.TEXT_NODE && n.textContent?.includes("Line B")) {
+            lineBNode = n;
+            break;
+        }
+    }
+
+    if (lineBNode) {
+        const sel = window.getSelection()!;
+        const range = document.createRange();
+        range.setStart(lineBNode, 0);
+        range.collapse(true);
+        sel.removeAllRanges();
+        sel.addRange(range);
+    }
+
+    await userEvent.keyboard("{Backspace}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "restored + Backspace join");
+    const value = getStoredValue("kb-test");
+    console.log(`[restored + Backspace join] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Line ALine B");
+});
+
+// ---------------------------------------------------------------------------
+// Triple round-trip: the exact user scenario
+// Type → save → restore → edit within → save → restore → verify
+// ---------------------------------------------------------------------------
+
+test("triple round-trip: type 3 lines, save, restore, add 4th, save, restore, verify", async () => {
+    const el = getElement();
+
+    // Round 1: type from scratch
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    await selectAll(el);
+    await userEvent.keyboard("One");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Two");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Three");
+    await new Promise((r) => setTimeout(r, 100));
+
+    const r1 = getStoredValue("kb-test");
+    console.log(`[triple] round 1 typed: ${JSON.stringify(r1)}`);
+    dumpDOM(el, "triple r1 typed");
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    dumpDOM(el, "triple r1 after save+deselect");
+    const r1saved = getStoredValue("kb-test");
+    console.log(`[triple] round 1 saved: ${JSON.stringify(r1saved)}`);
+
+    // Round 2: click to edit restored content, go to end, add a line
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    dumpDOM(el, "triple r2 after click");
+
+    // Move cursor to very end
+    const sel2 = window.getSelection()!;
+    const range2 = document.createRange();
+    range2.selectNodeContents(el);
+    range2.collapse(false);
+    sel2.removeAllRanges();
+    sel2.addRange(range2);
+
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Four");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "triple r2 after adding Four");
+    const r2 = getStoredValue("kb-test");
+    console.log(`[triple] round 2 edited: ${JSON.stringify(r2)}`);
+
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    dumpDOM(el, "triple r2 after save+deselect");
+    const r2saved = getStoredValue("kb-test");
+    console.log(`[triple] round 2 saved: ${JSON.stringify(r2saved)}`);
+
+    // Round 3: click to edit again, go to end, add another line
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    dumpDOM(el, "triple r3 after click");
+
+    const sel3 = window.getSelection()!;
+    const range3 = document.createRange();
+    range3.selectNodeContents(el);
+    range3.collapse(false);
+    sel3.removeAllRanges();
+    sel3.addRange(range3);
+
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Five");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "triple r3 after adding Five");
+    const r3 = getStoredValue("kb-test");
+    console.log(`[triple] round 3 edited: ${JSON.stringify(r3)}`);
+
+    expect(r3).toBe("One\nTwo\nThree\nFour\nFive");
+});
+
+// ---------------------------------------------------------------------------
+// Trailing Enter: type text, press Enter at end, save, restore, verify
+// ---------------------------------------------------------------------------
+
+test("trailing Enter survives full save → restore → re-read cycle", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Hello");
+    await userEvent.keyboard("{Enter}");
+    // Don't type anything — just a trailing blank line
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "trailing-cycle: after typing");
+    const afterType = getStoredValue("kb-test");
+    console.log(`[trailing-cycle] after type: ${JSON.stringify(afterType)}`);
+    expect(afterType).toBe("Hello\n");
+
+    // Save
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    const afterSave = getStoredValue("kb-test");
+    console.log(`[trailing-cycle] after save: ${JSON.stringify(afterSave)}`);
+    expect(afterSave).toBe("Hello\n");
+
+    // Deselect
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    dumpDOM(el, "trailing-cycle: after deselect");
+    const afterDeselect = getStoredValue("kb-test");
+    console.log(`[trailing-cycle] after deselect: ${JSON.stringify(afterDeselect)}`);
+
+    // Now simulate what a page refresh does: restore from the saved value
+    // This goes through writeTextWithBreaks → readTextWithBreaks
+    const el2 = await restoreAndEdit(afterDeselect);
+    dumpDOM(el2, "trailing-cycle: after restore+edit");
+    const afterRestore = getStoredValue("kb-test");
+    console.log(`[trailing-cycle] after restore: ${JSON.stringify(afterRestore)}`);
+
+    expect(afterRestore).toBe("Hello\n");
+});
+
+test("trailing Enter after multiple lines survives restore", async () => {
+    const el = getElement();
+    await userEvent.click(el);
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    await selectAll(el);
+    await userEvent.keyboard("Line one");
+    await userEvent.keyboard("{Enter}");
+    await userEvent.keyboard("Line two");
+    await userEvent.keyboard("{Enter}");
+    // Trailing blank line
+    await new Promise((r) => setTimeout(r, 100));
+
+    const afterType = getStoredValue("kb-test");
+    console.log(`[trailing-multi] after type: ${JSON.stringify(afterType)}`);
+    expect(afterType).toBe("Line one\nLine two\n");
+
+    // Save and restore
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    const el2 = await restoreAndEdit(getStoredValue("kb-test"));
+    dumpDOM(el2, "trailing-multi: after restore+edit");
+    const afterRestore = getStoredValue("kb-test");
+    console.log(`[trailing-multi] after restore: ${JSON.stringify(afterRestore)}`);
+
+    expect(afterRestore).toBe("Line one\nLine two\n");
+});
+
+test("trailing Enter on restored <br> content produces 2 newlines", async () => {
+    // Restore content that has a <br> (from a previous save of "Hello\n...")
+    // Then press Enter at the end — Chrome produces text<br><div><br></div>
+    const el = await restoreAndEdit("Hello");
+
+    // Move cursor to very end
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard("{Enter}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "trailing-restored: after Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[trailing-restored] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Hello\n");
+});
+
+test("trailing Enter on restored multi-line <br> content is not lost", async () => {
+    // Restore "Line one\nLine two" → DOM: Line one<br>Line two
+    // Then press Enter at end → should get "Line one\nLine two\n"
+    const el = await restoreAndEdit("Line one\nLine two");
+
+    // Move cursor to very end
+    const sel = window.getSelection()!;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+
+    await userEvent.keyboard("{Enter}");
+    await new Promise((r) => setTimeout(r, 100));
+
+    dumpDOM(el, "trailing-restored-multi: after Enter");
+    const value = getStoredValue("kb-test");
+    console.log(`[trailing-restored-multi] serialized: ${JSON.stringify(value)}`);
+
+    expect(value).toBe("Line one\nLine two\n");
+
+    // Save, restore, verify it round-trips
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 200));
+
+    const el2 = await restoreAndEdit(getStoredValue("kb-test"));
+    dumpDOM(el2, "trailing-restored-multi: after full round-trip");
+    const afterRoundTrip = getStoredValue("kb-test");
+    console.log(`[trailing-restored-multi] after round-trip: ${JSON.stringify(afterRoundTrip)}`);
+
+    expect(afterRoundTrip).toBe("Line one\nLine two\n");
+});

--- a/tests/browser/desktop/editing/text-line-breaks.test.ts
+++ b/tests/browser/desktop/editing/text-line-breaks.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Text element line break tests
+ *
+ * Comprehensive scenario tests for line breaks in text elements.
+ * Covers the full edit → serialize → save → restore → re-edit cycle
+ * with all the DOM variations that browsers produce in contenteditable.
+ */
+
+import { test, expect, beforeAll, afterEach } from "vitest";
+import {
+    initializeSDK,
+    waitForCondition,
+    clickToolbarButton,
+    setupTestHelpers,
+    getController,
+} from "~/@browser-support/sdk-helpers.js";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import type { Toolbar } from "~/src/components/toolbar.js";
+
+let appId: string;
+
+/**
+ * Set the innerHTML of a text element as if the user typed it,
+ * then fire an input event so the SDK picks up the change.
+ */
+function simulateTyping(element: HTMLElement, html: string): void {
+    element.innerHTML = html;
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+/**
+ * Read the SDK's serialized value for a text element from currentContent.
+ * Returns the parsed `value` string (with \n for line breaks).
+ */
+function getStoredValue(key: string): string {
+    const state = (getController() as unknown as { state: { currentContent: Map<string, string> } })
+        .state;
+    const raw = state.currentContent.get(key);
+    if (!raw) throw new Error(`No currentContent for key "${key}"`);
+    return (JSON.parse(raw) as { value: string }).value;
+}
+
+function getToolbar(): Toolbar {
+    return document.querySelector("scms-toolbar") as Toolbar;
+}
+
+function getTextElement(): HTMLElement {
+    return document.querySelector('[data-scms-text="line-break-test"]') as HTMLElement;
+}
+
+beforeAll(async () => {
+    setupTestHelpers();
+    const { generateTestAppId } = await import("~/@browser-support/sdk-helpers.js");
+    appId = generateTestAppId();
+
+    // Pre-populate with multi-line content
+    await setContent(
+        appId,
+        "line-break-test",
+        JSON.stringify({ type: "text", value: "Line one\nLine two\nLine three" }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+afterEach(async () => {
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+});
+
+// ---------------------------------------------------------------------------
+// Initial load
+// ---------------------------------------------------------------------------
+
+test("stored \\n renders as <br> on initial load", () => {
+    const el = getTextElement();
+    const brs = el.querySelectorAll("br");
+    expect(brs.length).toBe(2);
+    expect(el.textContent).toBe("Line oneLine twoLine three");
+});
+
+test("SDK serializes loaded content back to the same \\n format", () => {
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Line one\nLine two\nLine three");
+});
+
+// ---------------------------------------------------------------------------
+// Chrome-style contenteditable: Enter wraps lines in <div>
+// ---------------------------------------------------------------------------
+
+test("Chrome <div> line breaks are serialized as \\n", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Chrome wraps each line after the first in a <div>
+    simulateTyping(el, "Alpha<div>Bravo</div><div>Charlie</div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Alpha\nBravo\nCharlie");
+});
+
+test("Chrome empty lines (<div><br></div>) serialize as empty \\n", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "Before<div><br></div><div>After</div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Before\n\nAfter");
+});
+
+test("multiple consecutive empty lines are preserved", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "Top<div><br></div><div><br></div><div><br></div><div>Bottom</div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Top\n\n\n\nBottom");
+});
+
+// ---------------------------------------------------------------------------
+// <br>-style line breaks (Shift+Enter, Firefox, or our own restore)
+// ---------------------------------------------------------------------------
+
+test("standalone <br> tags serialize as \\n", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "First<br>Second<br>Third");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("First\nSecond\nThird");
+});
+
+test("mixed <br> and <div> serialize consistently", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Shift+Enter then Enter in Chrome can produce mixed markup
+    simulateTyping(el, "Line A<br>Line B<div>Line C</div><div>Line D</div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Line A\nLine B\nLine C\nLine D");
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip: edit → save → reload content → verify DOM
+// ---------------------------------------------------------------------------
+
+test("full round-trip: edit with divs, save, verify serialized value", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Simulate a realistic editing session
+    simulateTyping(
+        el,
+        "Heading<div><br></div><div>Paragraph one</div><div>Paragraph two</div><div><br></div><div>Footer</div>",
+    );
+
+    // Verify serialization
+    const serialized = getStoredValue("line-break-test");
+    expect(serialized).toBe("Heading\n\nParagraph one\nParagraph two\n\nFooter");
+
+    // Save
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    // After save, the visual content is still correct (lines are separate)
+    expect(el.textContent).toContain("Heading");
+    expect(el.textContent).toContain("Paragraph one");
+    expect(el.textContent).toContain("Footer");
+
+    // The serialized value should still be intact
+    const valueAfterSave = getStoredValue("line-break-test");
+    expect(valueAfterSave).toBe("Heading\n\nParagraph one\nParagraph two\n\nFooter");
+});
+
+test("round-trip preserves content after re-selecting the element", async () => {
+    const el = getTextElement();
+
+    // First, set known content via the SDK save path
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+    simulateTyping(el, "AAA<div>BBB</div><div>CCC</div>");
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    // Deselect
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Re-select — content should still be intact
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // The serialized value should still have the correct line breaks
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("AAA\nBBB\nCCC");
+
+    // Visual content should still show all three lines
+    expect(el.textContent).toContain("AAA");
+    expect(el.textContent).toContain("BBB");
+    expect(el.textContent).toContain("CCC");
+});
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+test("single line with no breaks serializes cleanly", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "Just one line");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Just one line");
+});
+
+test("empty element serializes as empty string", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("");
+});
+
+test("only empty lines serialize correctly", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // User pressed Enter three times with no text
+    simulateTyping(el, "<div><br></div><div><br></div><div><br></div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("\n\n\n");
+});
+
+test("trailing empty line is preserved", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    simulateTyping(el, "Content<div><br></div>");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("Content\n");
+});
+
+test("leading empty line is preserved", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // This is unusual but possible if the user deletes text above
+    simulateTyping(el, "<br>Content");
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("\nContent");
+});
+
+test("special characters in text are not corrupted by line break handling", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Set content with special chars using textContent to avoid HTML interpretation
+    el.textContent = "";
+    el.appendChild(document.createTextNode("Price: $5 & <tax>"));
+    el.appendChild(document.createElement("br"));
+    el.appendChild(document.createTextNode('She said "hello"'));
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe('Price: $5 & <tax>\nShe said "hello"');
+});
+
+test("nested divs (unusual but possible from paste) are handled", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Pasting from some editors can create nested block elements
+    simulateTyping(el, "Outer<div><div>Inner</div></div><div>Last</div>");
+
+    const value = getStoredValue("line-break-test");
+    // Both div boundaries should produce line breaks
+    expect(value).toBe("Outer\n\nInner\nLast");
+});
+
+test("the user scenario from issue #81: multi-line text with gaps", async () => {
+    const el = getTextElement();
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    // Reproduce the exact DOM Chrome would create for the issue reporter's input:
+    // "This paragraph..." then Enter Enter "1" Enter "2" Enter "3" Enter Enter "Something" Enter Enter "4" Enter "5"
+    simulateTyping(
+        el,
+        [
+            "This paragraph can be edited.",
+            "<div><br></div>",
+            "<div>1</div>",
+            "<div>2</div>",
+            "<div>3</div>",
+            "<div><br></div>",
+            "<div>Something</div>",
+            "<div><br></div>",
+            "<div>4</div>",
+            "<div>5</div>",
+        ].join(""),
+    );
+
+    const value = getStoredValue("line-break-test");
+    expect(value).toBe("This paragraph can be edited.\n\n1\n2\n3\n\nSomething\n\n4\n5");
+
+    // Save
+    await clickToolbarButton("Save");
+    await waitForCondition(() => !getToolbar().hasChanges, 5000);
+
+    // Visual content should still contain all items
+    expect(el.textContent).toContain("This paragraph can be edited.");
+    expect(el.textContent).toContain("1");
+    expect(el.textContent).toContain("Something");
+    expect(el.textContent).toContain("5");
+
+    // Deselect, re-select, and verify the serialized value is still correct
+    document.body.click();
+    await new Promise((r) => setTimeout(r, 100));
+    el.click();
+    await waitForCondition(() => el.classList.contains("streamlined-editing"));
+
+    const valueAfterReload = getStoredValue("line-break-test");
+    expect(valueAfterReload).toBe("This paragraph can be edited.\n\n1\n2\n3\n\nSomething\n\n4\n5");
+});

--- a/tests/browser/desktop/modals/accessibility-modal.test.ts
+++ b/tests/browser/desktop/modals/accessibility-modal.test.ts
@@ -282,14 +282,6 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openAccessibilityModalForLink();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});
-
 test("can toggle not-applicable fields section", async () => {
     const modal = await openAccessibilityModalForLink();
     const shadowRoot = modal.shadowRoot!;

--- a/tests/browser/desktop/modals/attributes-modal.test.ts
+++ b/tests/browser/desktop/modals/attributes-modal.test.ts
@@ -310,10 +310,3 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openAttributesModal();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});

--- a/tests/browser/desktop/modals/attributes-modal.test.ts
+++ b/tests/browser/desktop/modals/attributes-modal.test.ts
@@ -309,4 +309,3 @@ test("clicking backdrop cancels the modal", async () => {
     await waitForCondition(() => cancelCalled);
     expect(cancelCalled).toBe(true);
 });
-

--- a/tests/browser/desktop/modals/html-editor.test.ts
+++ b/tests/browser/desktop/modals/html-editor.test.ts
@@ -10,9 +10,11 @@ import {
     waitForCondition,
     waitForSelector,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 import type { HtmlEditorModal } from "~/src/components/html-editor-modal.js";
+import type { FormattingToolbar } from "~/src/components/rich-text-editor.js";
 
 beforeAll(async () => {
     setupTestHelpers();
@@ -42,7 +44,7 @@ async function openHtmlEditorModal(): Promise<HtmlEditorModal> {
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    const clicked = await clickToolbarButton("Edit HTML");
+    const clicked = await clickToolbarButton("View Source");
     expect(clicked).toBe(true);
 
     await waitForSelector("scms-html-editor-modal");
@@ -71,7 +73,7 @@ beforeEach(async () => {
     await resetState();
 });
 
-test("clicking Edit HTML opens the modal", async () => {
+test("clicking View Source opens the modal", async () => {
     const modal = await openHtmlEditorModal();
 
     expect(modal).not.toBeNull();
@@ -80,7 +82,6 @@ test("clicking Edit HTML opens the modal", async () => {
 
 test("modal shows current HTML content", async () => {
     const element = getHtmlElement();
-    const originalContent = element.innerHTML;
 
     const modal = await openHtmlEditorModal();
     const shadowRoot = modal.shadowRoot!;
@@ -88,7 +89,9 @@ test("modal shows current HTML content", async () => {
     await new Promise((r) => setTimeout(r, 100));
 
     const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.value).toBe(originalContent);
+    // The modal shows the element's text content (may differ from innerHTML
+    // if Tiptap has normalized the DOM, e.g., wrapping bare text in <p>)
+    expect(textarea.value).toContain(element.textContent?.trim() || "");
 });
 
 test("can edit HTML content in textarea", async () => {
@@ -221,10 +224,68 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
+test("Tiptap to modal sync: inline edits appear in View Source", async () => {
+    const element = getHtmlElement();
+
+    // Click element to start editing (Tiptap attaches)
+    element.click();
+    await waitForCondition(() => element.classList.contains("streamlined-editing"));
+
+    // Edit content via Tiptap
+    setElementContent(element, "<p>Edited inline via Tiptap</p>");
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Open View Source modal
+    const clicked = await clickToolbarButton("View Source");
+    expect(clicked).toBe(true);
+    await waitForSelector("scms-html-editor-modal");
+
+    const modal = getHtmlEditorModal()!;
+    const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Modal textarea should show the Tiptap content
+    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
+    expect(textarea.value).toContain("Edited inline via Tiptap");
+});
+
+test("modal to Tiptap sync: View Source edits update inline editor", async () => {
+    const element = getHtmlElement();
+
+    // Open modal (this clicks element first, attaching Tiptap)
     const modal = await openHtmlEditorModal();
     const shadowRoot = modal.shadowRoot!;
+    await new Promise((r) => setTimeout(r, 100));
 
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-title");
+    // Edit content in the modal textarea
+    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
+    textarea.value = "<p>Edited in View Source modal</p>";
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+
+    // Click Apply
+    const buttons = shadowRoot.querySelectorAll("button");
+    let applyBtn: HTMLButtonElement | null = null;
+    for (const btn of buttons) {
+        if (btn.textContent?.trim() === "Apply") {
+            applyBtn = btn;
+            break;
+        }
+    }
+    expect(applyBtn).not.toBeNull();
+    applyBtn!.click();
+
+    // Wait for modal to close and content to sync
+    await waitForCondition(() => getHtmlEditorModal() === null);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The formatting toolbar (Tiptap) should reflect the modal's content
+    const toolbar = document.querySelector(
+        "scms-formatting-toolbar",
+    ) as FormattingToolbar | null;
+    if (toolbar?.editor) {
+        expect(toolbar.getHTML()).toContain("Edited in View Source modal");
+    }
+
+    // The element's visible text should also reflect the change
+    expect(element.textContent).toContain("Edited in View Source modal");
 });

--- a/tests/browser/desktop/modals/html-editor.test.ts
+++ b/tests/browser/desktop/modals/html-editor.test.ts
@@ -279,9 +279,7 @@ test("modal to Tiptap sync: View Source edits update inline editor", async () =>
     await new Promise((r) => setTimeout(r, 100));
 
     // The formatting toolbar (Tiptap) should reflect the modal's content
-    const toolbar = document.querySelector(
-        "scms-formatting-toolbar",
-    ) as FormattingToolbar | null;
+    const toolbar = document.querySelector("scms-formatting-toolbar") as FormattingToolbar | null;
     if (toolbar?.editor) {
         expect(toolbar.getHTML()).toContain("Edited in View Source modal");
     }

--- a/tests/browser/desktop/modals/link-editor.test.ts
+++ b/tests/browser/desktop/modals/link-editor.test.ts
@@ -118,9 +118,6 @@ test("link editor modal shows current link values", async () => {
     const urlInput = shadowRoot.querySelector('input[type="url"]') as HTMLInputElement;
     expect(urlInput.value).toMatch(/^https:\/\/example\.com\/?$/);
 
-    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-    expect(textarea.value).toBe("Default Link Text");
-
     const targetSelect = shadowRoot.querySelector("select") as HTMLSelectElement;
     expect(targetSelect.value).toBe("");
 });
@@ -141,22 +138,6 @@ test("can edit link URL in the modal", async () => {
     // Verify the change is reflected
     await waitForCondition(() => urlInput.value === "https://newurl.com");
     expect(urlInput.value).toBe("https://newurl.com");
-});
-
-test("can edit link text in the modal", async () => {
-    const modal = await openLinkEditor();
-    const shadowRoot = modal.shadowRoot!;
-
-    await new Promise((r) => setTimeout(r, 100));
-
-    const textarea = shadowRoot.querySelector("textarea") as HTMLTextAreaElement;
-
-    // Change the link text
-    textarea.value = "New Link Text";
-    textarea.dispatchEvent(new Event("input", { bubbles: true }));
-
-    await waitForCondition(() => textarea.value === "New Link Text");
-    expect(textarea.value).toBe("New Link Text");
 });
 
 test("can change link target in the modal", async () => {
@@ -301,11 +282,3 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openLinkEditor();
-    const shadowRoot = modal.shadowRoot!;
-
-    // Find the element ID display in the header
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});

--- a/tests/browser/desktop/modals/link-editor.test.ts
+++ b/tests/browser/desktop/modals/link-editor.test.ts
@@ -281,4 +281,3 @@ test("clicking backdrop cancels the modal", async () => {
     await waitForCondition(() => cancelCalled);
     expect(cancelCalled).toBe(true);
 });
-

--- a/tests/browser/desktop/modals/seo-modal.test.ts
+++ b/tests/browser/desktop/modals/seo-modal.test.ts
@@ -317,14 +317,6 @@ test("clicking backdrop cancels the modal", async () => {
     expect(cancelCalled).toBe(true);
 });
 
-test("modal displays the element ID", async () => {
-    const modal = await openSeoModalForLink();
-    const shadowRoot = modal.shadowRoot!;
-
-    const elementIdSpan = shadowRoot.querySelector(".font-mono") as HTMLElement;
-    expect(elementIdSpan.textContent?.trim()).toBe("test-link");
-});
-
 test("can toggle not-applicable fields section", async () => {
     const modal = await openSeoModalForLink();
     const shadowRoot = modal.shadowRoot!;

--- a/tests/browser/desktop/save/basic.test.ts
+++ b/tests/browser/desktop/save/basic.test.ts
@@ -10,6 +10,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
     getController,
 } from "~/@browser-support/sdk-helpers.js";
@@ -55,8 +56,7 @@ async function editContent(element: HTMLElement, newContent: string): Promise<vo
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"));
 
-    element.innerHTML = newContent;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, newContent);
 
     await new Promise((r) => setTimeout(r, 100));
 }
@@ -105,8 +105,8 @@ test("saved content persists in element after save", async () => {
     await clickToolbarButton("Save");
     await waitForCondition(() => !getToolbar()!.hasChanges, 5000);
 
-    // Content should still be in the element
-    expect(element.innerHTML).toBe(newContent);
+    // Content should still be in the element (may be wrapped in tags by the editor)
+    expect(element.textContent).toContain(newContent);
 });
 
 test("hasChanges is false after successful save", async () => {
@@ -146,9 +146,9 @@ test("multiple elements can be edited and saved together", async () => {
     await clickToolbarButton("Save");
     await waitForCondition(() => !toolbar!.hasChanges, 5000);
 
-    // Both should be saved
-    expect(htmlElement.innerHTML).toBe("First element edited");
-    expect(paragraphElement.innerHTML).toBe("Second element edited");
+    // Both should be saved (content may be wrapped in tags by the editor)
+    expect(htmlElement.textContent).toContain("First element edited");
+    expect(paragraphElement.textContent).toContain("Second element edited");
 });
 
 test("Save button is only visible when there are changes", async () => {

--- a/tests/browser/desktop/save/error-handling.test.ts
+++ b/tests/browser/desktop/save/error-handling.test.ts
@@ -10,6 +10,7 @@ import {
     initializeSDK,
     waitForCondition,
     clickToolbarButton,
+    setElementContent,
     setupTestHelpers,
 } from "~/@browser-support/sdk-helpers.js";
 import { ERROR_TRIGGERS } from "~/@browser-support/test-helpers.js";
@@ -60,8 +61,7 @@ async function editContent(element: HTMLElement, content: string): Promise<void>
 
     element.click();
     await waitForCondition(() => element.classList.contains("streamlined-editing"), 3000);
-    element.innerHTML = content;
-    element.dispatchEvent(new Event("input", { bubbles: true }));
+    setElementContent(element, content);
     await new Promise((r) => setTimeout(r, 100));
 }
 
@@ -119,8 +119,8 @@ test("content is preserved after 500 error", async () => {
     // Wait for error to be processed
     await new Promise((r) => setTimeout(r, 500));
 
-    // Content should still be there
-    expect(element.innerHTML).toBe(editedContent);
+    // Content should still be there (may be wrapped in tags by the editor)
+    expect(element.textContent).toContain("Preserved content after error");
 });
 
 test("can retry save after 500 error", async () => {

--- a/tests/browser/desktop/templates/href-in-template.test.ts
+++ b/tests/browser/desktop/templates/href-in-template.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Href-in-template tests
+ *
+ * Regression coverage for the template bug that motivated data-scms-href:
+ * a data-scms-link inside a template had its developer-authored inner HTML
+ * wiped out during template instance creation. data-scms-href sidesteps this
+ * because it has no value field and stripTemplateContent preserves inner
+ * markup on href-typed editables.
+ */
+
+import { test, expect, beforeAll } from "vitest";
+import { setContent } from "~/@browser-support/test-helpers.js";
+import {
+    initializeSDK,
+    waitForCondition,
+    setupTestHelpers,
+    generateTestAppId,
+} from "~/@browser-support/sdk-helpers.js";
+
+beforeAll(async () => {
+    setupTestHelpers();
+    const appId = generateTestAppId();
+
+    // Seed two instances for the href-cards template.
+    await setContent(
+        appId,
+        "href-cards.card1.cta",
+        JSON.stringify({
+            type: "href",
+            href: "https://example.com/one",
+            target: "",
+        }),
+    );
+    await setContent(
+        appId,
+        "href-cards.card2.cta",
+        JSON.stringify({
+            type: "href",
+            href: "https://example.com/two",
+            target: "_blank",
+        }),
+    );
+    await setContent(
+        appId,
+        "href-cards._order",
+        JSON.stringify({ type: "order", value: ["card1", "card2"] }),
+    );
+
+    await initializeSDK({ appId });
+});
+
+function getCards(): HTMLElement[] {
+    const container = document.querySelector('[data-scms-template="href-cards"]');
+    return Array.from(container?.querySelectorAll(".href-card") ?? []) as HTMLElement[];
+}
+
+test("seeded instances preserve developer-authored inner HTML inside data-scms-href", () => {
+    const cards = getCards();
+    expect(cards.length).toBe(2);
+
+    for (const card of cards) {
+        const anchor = card.querySelector("[data-scms-href]") as HTMLAnchorElement;
+        expect(anchor).not.toBeNull();
+        // Icon and label survived stripTemplateContent + instance cloning.
+        expect(anchor.querySelector('[data-testid="href-tmpl-icon"]')).not.toBeNull();
+        expect(anchor.querySelector('[data-testid="href-tmpl-label"]')).not.toBeNull();
+        expect(anchor.textContent?.trim()).toContain("Card CTA");
+    }
+});
+
+test("href and target apply from seeded content", () => {
+    const cards = getCards();
+    const anchors = cards.map(
+        (c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement,
+    );
+
+    expect(anchors[0].getAttribute("href")).toBe("https://example.com/one");
+    expect(anchors[0].target).toBe("");
+
+    expect(anchors[1].getAttribute("href")).toBe("https://example.com/two");
+    expect(anchors[1].target).toBe("_blank");
+});
+
+test("new instance from the add button keeps inner HTML", async () => {
+    const container = document.querySelector(
+        '[data-scms-template="href-cards"]',
+    ) as HTMLElement;
+    const initialCount = container.querySelectorAll(".href-card").length;
+
+    const addButton = container.querySelector(".scms-template-add") as HTMLElement;
+    addButton.click();
+
+    await waitForCondition(
+        () => container.querySelectorAll(".href-card").length === initialCount + 1,
+    );
+
+    const cards = container.querySelectorAll(".href-card");
+    const newCard = cards[cards.length - 1];
+    const anchor = newCard.querySelector("[data-scms-href]") as HTMLAnchorElement;
+    expect(anchor).not.toBeNull();
+
+    // Critical: inner icon + label survived into the newly cloned instance.
+    expect(anchor.querySelector('[data-testid="href-tmpl-icon"]')).not.toBeNull();
+    expect(anchor.querySelector('[data-testid="href-tmpl-label"]')).not.toBeNull();
+});

--- a/tests/browser/desktop/templates/href-in-template.test.ts
+++ b/tests/browser/desktop/templates/href-in-template.test.ts
@@ -70,9 +70,7 @@ test("seeded instances preserve developer-authored inner HTML inside data-scms-h
 
 test("href and target apply from seeded content", () => {
     const cards = getCards();
-    const anchors = cards.map(
-        (c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement,
-    );
+    const anchors = cards.map((c) => c.querySelector("[data-scms-href]") as HTMLAnchorElement);
 
     expect(anchors[0].getAttribute("href")).toBe("https://example.com/one");
     expect(anchors[0].target).toBe("");
@@ -82,9 +80,7 @@ test("href and target apply from seeded content", () => {
 });
 
 test("new instance from the add button keeps inner HTML", async () => {
-    const container = document.querySelector(
-        '[data-scms-template="href-cards"]',
-    ) as HTMLElement;
+    const container = document.querySelector('[data-scms-template="href-cards"]') as HTMLElement;
     const initialCount = container.querySelectorAll(".href-card").length;
 
     const addButton = container.querySelector(".scms-template-add") as HTMLElement;

--- a/tests/browser/desktop/toolbar/buttons.test.ts
+++ b/tests/browser/desktop/toolbar/buttons.test.ts
@@ -50,17 +50,17 @@ beforeEach(async () => {
 
 // --- HTML element tests ---
 
-test("Edit HTML button appears for html-type elements", async () => {
+test("Edit Content button appears for html-type elements", async () => {
     const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
     htmlElement.click();
 
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit HTML"))).toBe(true);
+    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(true);
 });
 
-test("Edit HTML button does NOT appear for text-type elements", async () => {
+test("Edit Content button does NOT appear for text-type elements", async () => {
     const textElement = document.querySelector('[data-scms-text="name"]') as HTMLElement;
     if (!textElement) {
         // Skip if no text element available
@@ -71,7 +71,7 @@ test("Edit HTML button does NOT appear for text-type elements", async () => {
     await waitForCondition(() => textElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit HTML"))).toBe(false);
+    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(false);
 });
 
 // --- Link element tests ---

--- a/tests/browser/desktop/toolbar/buttons.test.ts
+++ b/tests/browser/desktop/toolbar/buttons.test.ts
@@ -50,17 +50,17 @@ beforeEach(async () => {
 
 // --- HTML element tests ---
 
-test("Edit Content button appears for html-type elements", async () => {
+test("View Source button appears for html-type elements", async () => {
     const htmlElement = document.querySelector('[data-scms-html="test-title"]') as HTMLElement;
     htmlElement.click();
 
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(true);
+    expect(buttonTexts.some((t) => t.includes("View Source"))).toBe(true);
 });
 
-test("Edit Content button does NOT appear for text-type elements", async () => {
+test("View Source button does NOT appear for text-type elements", async () => {
     const textElement = document.querySelector('[data-scms-text="name"]') as HTMLElement;
     if (!textElement) {
         // Skip if no text element available
@@ -71,7 +71,7 @@ test("Edit Content button does NOT appear for text-type elements", async () => {
     await waitForCondition(() => textElement.classList.contains("streamlined-editing"));
 
     const buttonTexts = getToolbarButtonTexts();
-    expect(buttonTexts.some((t) => t.includes("Edit Content"))).toBe(false);
+    expect(buttonTexts.some((t) => t.includes("View Source"))).toBe(false);
 });
 
 // --- Link element tests ---
@@ -120,8 +120,8 @@ test("Save button appears when there are changes", async () => {
     await waitForCondition(() => htmlElement.classList.contains("streamlined-editing"));
 
     // Make a change
-    htmlElement.innerHTML = "Modified content for save test";
-    htmlElement.dispatchEvent(new Event("input", { bubbles: true }));
+    const { setElementContent } = await import("~/@browser-support/sdk-helpers.js");
+    setElementContent(htmlElement, "Modified content for save test");
 
     await new Promise((r) => setTimeout(r, 100));
 

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -51,7 +51,7 @@
 
         <!-- Elements for drafts tests (isolated) -->
         <div class="test-section">
-            <h1 data-scms-html="draft-test-title">Draft Test Title</h1>
+            <h1 data-scms-html="draft-test-title"><p>Draft Test Title</p></h1>
         </div>
 
         <!-- Template test section -->

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -42,6 +42,15 @@
             <p data-scms-text="kb-test">Default keyboard test text</p>
         </div>
 
+        <!-- Elements for empty-placeholder tests (isolated) -->
+        <div class="test-section">
+            <h2>Empty Placeholder Test</h2>
+            <p data-scms-text="placeholder-text">Some text</p>
+            <p data-scms-html="placeholder-html">Some <strong>html</strong></p>
+            <a href="https://example.com" data-scms-link="placeholder-link">Some link</a>
+            <span data-scms-html="placeholder-inline-html">Inline html</span>
+        </div>
+
         <!-- Elements for save/basic tests (isolated) -->
         <div class="test-section">
             <h1 data-scms-html="save-basic-title">Save Basic Title</h1>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -31,6 +31,42 @@
             <a href="https://example.com" data-scms-link="test-link">Default Link Text</a>
         </div>
 
+        <!-- Href element: link metadata only, inner content is developer-authored -->
+        <div class="test-section">
+            <a href="https://example.com/href" data-scms-href="test-href">
+                <i class="icon-star" data-testid="href-icon"></i>
+                <span data-testid="href-label">Learn more</span>
+            </a>
+        </div>
+
+        <!-- Href conflict: also has data-scms-text (should warn; text wins) -->
+        <div class="test-section">
+            <a
+                href="https://example.com/conflict"
+                data-scms-href="test-href-conflict"
+                data-scms-text="test-conflict-text"
+                >Conflicting Link</a
+            >
+        </div>
+
+        <!-- Href on non-anchor (should warn and skip) -->
+        <div class="test-section">
+            <div data-scms-href="test-href-nonanchor">Not an anchor</div>
+        </div>
+
+        <!-- Template containing a data-scms-href with rich inner layout -->
+        <div class="test-section">
+            <h2>Href-in-template</h2>
+            <div data-scms-template="href-cards" class="href-card-container">
+                <div class="href-card">
+                    <a href="https://example.com/card" data-scms-href="cta">
+                        <i class="icon-arrow" data-testid="href-tmpl-icon"></i>
+                        <span data-testid="href-tmpl-label">Card CTA</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+
         <!-- Elements for content-parsing tests (isolated) -->
         <div class="test-section">
             <a href="https://example.com" data-scms-link="test-link-parsing">Default Link Text</a>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -54,6 +54,19 @@
             <div data-scms-href="test-href-nonanchor">Not an anchor</div>
         </div>
 
+        <!-- Href containing html as an immediate child (tests outer-select navigation) -->
+        <div class="test-section">
+            <a
+                href="https://example.com/wrap"
+                data-scms-href="test-href-wrapper"
+                style="display: block"
+            >
+                <div data-scms-html="test-wrapped-html" style="padding: 10px">
+                    <strong>Wrapped</strong> HTML content
+                </div>
+            </a>
+        </div>
+
         <!-- Template containing a data-scms-href with rich inner layout -->
         <div class="test-section">
             <h2>Href-in-template</h2>

--- a/tests/browser/support/fixtures/tester.html
+++ b/tests/browser/support/fixtures/tester.html
@@ -36,6 +36,10 @@
             <a href="https://example.com" data-scms-link="test-link-parsing">Default Link Text</a>
             <h1 data-scms-html="test-title-parsing">Parsing Title</h1>
             <p data-scms-html="test-paragraph-parsing">Parsing paragraph.</p>
+            <p data-scms-text="test-line-breaks">Default line breaks text</p>
+            <p data-scms-text="test-text-escaping">Default escaping text</p>
+            <p data-scms-text="line-break-test">Default line break scenario text</p>
+            <p data-scms-text="kb-test">Default keyboard test text</p>
         </div>
 
         <!-- Elements for save/basic tests (isolated) -->

--- a/tests/browser/support/sdk-helpers.ts
+++ b/tests/browser/support/sdk-helpers.ts
@@ -161,6 +161,26 @@ export async function clickToolbarButton(text: string): Promise<boolean> {
 }
 
 /**
+ * Edit the content of an element in a Tiptap-aware way.
+ * If the formatting toolbar has Tiptap attached to the element,
+ * uses Tiptap's API. Otherwise falls back to setting innerHTML directly.
+ */
+export function setElementContent(element: HTMLElement, newContent: string): void {
+    const toolbar = document.querySelector("scms-formatting-toolbar") as HTMLElement | null;
+    const target = toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
+
+    if (target === element) {
+        // Tiptap is managing this element — use its API
+        const setContent = (toolbar as unknown as { setContent: (html: string) => void }).setContent;
+        setContent.call(toolbar, newContent);
+    } else {
+        // No Tiptap — set innerHTML directly
+        element.innerHTML = newContent;
+        element.dispatchEvent(new Event("input", { bubbles: true }));
+    }
+}
+
+/**
  * Setup function to be called in beforeAll
  */
 export function setupTestHelpers(): void {

--- a/tests/browser/support/sdk-helpers.ts
+++ b/tests/browser/support/sdk-helpers.ts
@@ -167,11 +167,13 @@ export async function clickToolbarButton(text: string): Promise<boolean> {
  */
 export function setElementContent(element: HTMLElement, newContent: string): void {
     const toolbar = document.querySelector("scms-formatting-toolbar") as HTMLElement | null;
-    const target = toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
+    const target =
+        toolbar && (toolbar as unknown as { targetElement: HTMLElement | null }).targetElement;
 
     if (target === element) {
         // Tiptap is managing this element — use its API
-        const setContent = (toolbar as unknown as { setContent: (html: string) => void }).setContent;
+        const setContent = (toolbar as unknown as { setContent: (html: string) => void })
+            .setContent;
         setContent.call(toolbar, newContent);
     } else {
         // No Tiptap — set innerHTML directly


### PR DESCRIPTION
## Summary

Release v1.2.0. The headline change is inline rich text editing via Tiptap, plus a new `data-scms-href` link API and a grab-bag of editing UX fixes.

## Highlights

### Features
- **Inline rich text editing with Tiptap** (#84) — headings, paragraph, links, undo, custom schema; Tiptap also powers the link and HTML editor modals
- **`data-scms-href` link type** (#87) — non-content editable for `<a>` elements that tracks only `href`/`target`, leaving the anchor's inner HTML entirely under the developer's control. Fixes template bugs where `data-scms-link` wiped developer-authored inner markup (icons, nested editables). Includes an outer-editable toolbar button to walk up from a nested editable to its ancestor
- **Content viewer overlay** (earlier in the cycle) — discover and select editables via visual badges

### Fixes
- Line-break preservation in `data-scms-text` (#83) — handles `<br>`, Chrome's `<div>`-per-Enter, paste variants, and `&nbsp;` normalization; XSS-safe writes
- 'Click to edit' placeholder for empty editables (#86) — JS-managed `streamlined-empty` class replaces the CSS `:empty` rule, handles stray `<br>` and empty `<p>` wrappers
- First-click caret placement (#90) — Tiptap caret now lands at the click point on the first click instead of requiring a second; new semi-transparent outline keeps the caret visible
- Enter in Tiptap creates `<p>` instead of `<span>`
- Defensive re-enable of `contenteditable` when reusing a Tiptap editor
- Stop managing `contenteditable` on html elements in editing-manager
- Mobile formatting toolbar layout and viewport handling
- Go to Link toolbar button, paragraph control, heading toggle fix

### Docs/infra
- Integration guide rewritten: `data-scms-href` documented as the recommended link API; `data-scms-link` marked deprecated and unsafe inside templates
- SDK lifecycle docs clarified (two-phase loading)
- `deploy-prod` PR lookup timing fixed; master always syncs back to develop

## Release mechanics
- Merge with `release:minor` label triggers `deploy-prod.yml`: bumps to 1.2.0, tags, builds, uploads to prod CDN, publishes with aliases, syncs master → develop.

## Test plan
- [x] `npm test` passing on develop
- [ ] Post-merge: verify v1.2.0 tag created, CDN upload + publish succeeded, develop auto-synced